### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Penetration testers and bug hunters will find FakeNet-NG's configurable
 interception engine and modular framework highly useful when testing
 application's specific functionality and prototyping PoCs.
 
+The current version, 3.0 (alpha), is a pre-release of the Python 3 port of FakeNet-NG.
+If you encounter any bugs in this version, please report them via GitHub issues.
+
 Installation
 ============
 
@@ -88,7 +91,7 @@ install dependencies as follows:
    driver in the `%PYTHONHOME%\DLLs` directory. FakeNet-NG bundles those
    files so they are not necessary for normal use.
 
-2b) Optionally, you can install the following module used for testing:
+   Optionally, you can install the following module used for testing:
 
     pip install requests
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -181,9 +181,7 @@ utilities (i.e. `pip`). Use an administrative command prompt where applicable
 for installing Python modules for all users.
 
 Pre-requisites:
-* Python 2.7 x86 with `pip`
-* Visual C++ for Python 2.7 development, available at:
-  <https://aka.ms/vcpython27>
+* Python 3.7.x x86 with `pip`
 
 Before installing `pyinstaller`, you may wish to take the following steps to
 prevent the error `ImportError: No module named PyInstaller`:
@@ -197,13 +195,6 @@ Install FakeNet-NG to acquire most modules:
 
 ```
 python setup.py install
-```
-
-Obtain PyDivert 2.0.9, the only version known to work with FakeNet-NG releases
-prepared with PyInstaller:
-
-```
-pip install pydivert==2.0.9
 ```
 
 Install `pyinstaller`:
@@ -245,7 +236,6 @@ fakenet1.4.3\
     |   +-- CustomProviderExample.py
     |   +-- sample_custom_response.ini
     |   +-- sample_raw_response.txt
-    |   +-- sample_raw_tcp_response.txt
     |
     +-- defaultFiles\
     |   +-- FakeNet.gif
@@ -260,7 +250,7 @@ fakenet1.4.3\
     |
     +-- listeners\
         +-- ssl_utils
-    		+-- __init__.pyc
+    		+-- __init__.py
     		+-- privkey.pem
     		+-- server.pem
     		+-- ssl_detector.py


### PR DESCRIPTION
* Update README.md to mention pre-release of Python 3 port
* Remove Visual C++ pre-requisite from developing.md
* Remove pydivert v2.0.9 requirement from release binary building documentation. Latest version of pydivert (v2.1.0) worked with pyinstaller.