### PR TITLE
Add support for WHOIS command on IRCListener

### DIFF
--- a/fakenet/listeners/IRCListener.py
+++ b/fakenet/listeners/IRCListener.py
@@ -159,6 +159,11 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         self.server.logger.info('Client issued an unknown command %s %s', cmd, params)      
         self.irc_send_server("421", "%s :Unknown command" % cmd)          
 
+    def irc_WHOIS(self, cmd, params):
+        output = f"ircname : {self.realname}\nhostname : {self.user}\nserver : {self.server}\nmodes : {self.mode}"
+        self.irc_send_server("001", f"{output}")
+        self.irc_send_server("001", "%s :End of WHOIS" % params)
+    
     def irc_NICK(self, cmd, params):
 
         self.nick = params


### PR DESCRIPTION
This PR fixes #35 

**Cause of Bug**
The reason of this `unknown command` bug is because there is no specific function in `fakenet/listeners/IRCListener.py` that deals with the `WHOIS` command. Therefore, whenever the `WHOIS` command is executed, the current code executes the `irc_DEFAULT` function in `fakenet/listeners/IRCListener.py`, that displays the `unknown command` message as output.

**Fix**
I went ahead and defined a function with the name `irc_WHOIS` which deals with the `WHOIS` command. I analyzed the ideal output of `WHOIS` command (executed without fakenet running), and then added the respective fields in the `irc_WHOIS` function to replicate the same output.

![idealWHOISOutput](https://drive.google.com/uc?export=view&id=10QhN5keQs3Sql7ZJ--WK2QV4cz28qbnw)


**Before**
` 27/03/23 01:45:34 PM [         IRCServer] Client issued an unknown command WHOIS IEUser`

**After**
![AfterChanges](https://drive.google.com/uc?export=view&id=1d_DWs9rVVHB-_OkCCF06T5O9ZajDOMkN)

**Note**
While the output is working as expected, there is one side effect. The WHOIS command's output keeps on printing in a forever loop at the client side, even though it is executed once. While I am trying to work on this issue and fix it, I would love any help to proceed in the right direction. Thank you! :)