### PR TITLE
Alter exit() to sys.exit() in ProxyListener.py.

### DIFF
--- a/fakenet/listeners/ProxyListener.py
+++ b/fakenet/listeners/ProxyListener.py
@@ -128,7 +128,7 @@ class ThreadedTCPClientSocket(threading.Thread):
                         self.listener_q.put(data)
                     else:
                         self.sock.close()
-                        exit(1)
+                        sys.exit(1)
         except Exception as e:
             self.logger.debug('Listener socket exception %s' % e.message)
 
@@ -332,7 +332,7 @@ def main():
         TCP_server.shutdown()
     finally:
         logger.debug('Closing ProxyListener')
-        exit(1)
+        sys.exit(1)
     logger.debug('Exiting')
     TCP_server.shutdown()
 


### PR DESCRIPTION
In relation to issue #161. 
https://github.com/mandiant/flare-fakenet-ng/issues/161