### PR TITLE
Use executable location as base for various file operations (#180)

### DIFF
--- a/fakenet/diverters/diverterbase.py
+++ b/fakenet/diverters/diverterbase.py
@@ -1967,11 +1967,12 @@ class DiverterBase(fnconfig.Config):
         
         timestamp = time.strftime('%Y%m%d_%H%M%S')
         output_filename = f"report_{timestamp}.html"
+        output_file_path = os.path.join(fakenet_dir_path, output_filename)
 
-        with open(output_filename, "w") as output_file:
+        with open(output_file_path, "w") as output_file:
             output_file.write(template.render(nbis=self.nbis))
         
-        self.logger.info(f"Generated new HTML report: {output_filename}")
+        self.logger.info(f"Generated new HTML report: {output_file_path}")
     
     
     

--- a/fakenet/diverters/diverterbase.py
+++ b/fakenet/diverters/diverterbase.py
@@ -1956,7 +1956,7 @@ class DiverterBase(fnconfig.Config):
         """
         if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
             # Inside a Pyinstaller bundle
-            fakenet_dir_path = os.getcwd()
+            fakenet_dir_path = os.path.dirname(sys.executable)
         else:
             fakenet_dir_path = os.fspath(Path(__file__).parents[1])
 

--- a/fakenet/fakenet.py
+++ b/fakenet/fakenet.py
@@ -64,7 +64,7 @@ class Fakenet(object):
     def parse_config(self, config_filename):
         # Handling Pyinstaller bundle scenario: https://pyinstaller.org/en/stable/runtime-information.html
         if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-            dir_path = os.getcwd()
+            dir_path = os.path.dirname(sys.executable)
         else:
             dir_path = os.path.dirname(__file__)
 

--- a/fakenet/listeners/ListenerBase.py
+++ b/fakenet/listeners/ListenerBase.py
@@ -34,7 +34,7 @@ def abs_config_path(path):
         return abspath
 
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-        relpath = os.path.join(os.getcwd(), path)
+        relpath = os.path.join(os.path.dirname(sys.executable), path)
     else:
 
         # Try to locate the location relative to application path

--- a/fakenet/listeners/TFTPListener.py
+++ b/fakenet/listeners/TFTPListener.py
@@ -211,8 +211,12 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
             if hasattr(self.server, 'filename_path') and self.server.filename_path:
 
                 safe_file = self.server.tftp_file_prefix + "_" + urllib.parse.quote(self.server.filename_path, '')
-                output_file = ListenerBase.safe_join(os.getcwd(),
-                                                          safe_file)
+                
+                if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+                    output_dir = os.path.dirname(sys.executable)
+                else:
+                    output_dir = os.path.dirname(__file__)
+                output_file = ListenerBase.safe_join(output_dir, safe_file)
                 f = open(output_file, 'ab')
                 f.write(data[4:])
                 f.close()


### PR DESCRIPTION
Currently, the FakeNet executable attempts to locate its files in the session's current working directory. However, this is not ideal as configuration files, for example, are actually located relative to the executable's location, not the location from which the user launched the executable. This issue was described in #180.

When inside a PyInstaller bundle, the parent directory of the executable can be retrieved using `os.path.dirname(sys.executable)`. 

I have applied this to various file operations throughout FakeNet. If I missed any, please let me know!