### PR TITLE
Fix for Issue 166

### DIFF
--- a/fakenet/diverters/diverterbase.py
+++ b/fakenet/diverters/diverterbase.py
@@ -958,7 +958,7 @@ class DiverterBase(fnconfig.Config):
         except KeyError as e:
             self.logger.error(('Failed to build ExecuteCmd for port %d due ' +
                               'to erroneous format key: %s') %
-                              (dport, e.message))
+                              (dport, str(e)))
 
         return cmd
 

--- a/fakenet/diverters/linutil.py
+++ b/fakenet/diverters/linutil.py
@@ -388,7 +388,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
             self.logger.debug(('Failed to open %s to enumerate netfilter '
                                'netlink queues, caller may proceed as if '
                                'none are in use: %s') %
-                              (procfs_path, e.message))
+                              (procfs_path, e))
 
         return qnos
 

--- a/fakenet/diverters/linutil.py
+++ b/fakenet/diverters/linutil.py
@@ -145,10 +145,10 @@ class LinuxDiverterNfqueue(object):
             self._bound = True
         except OSError as e:
             self.logger.error('Failed to start queue for %s: %s' %
-                              (str(self), e.message))
+                              (str(self), str(e)))
         except RuntimeWarning as e:
             self.logger.error('Failed to start queue for %s: %s' %
-                              (str(self), e.message))
+                              (str(self), str(e)))
 
         if not self._bound:
             return False
@@ -166,7 +166,7 @@ class LinuxDiverterNfqueue(object):
             self._thread.start()
             self._started = True
         except RuntimeError as e:
-            self.logger.error('Failed to start queue thread: %s' % (e.message))
+            self.logger.error('Failed to start queue thread: %s' % (str(e)))
 
         return self._started
 
@@ -251,7 +251,7 @@ class ProcfsReader(object):
                             retval = cb_retval
                             break
         except IOError as e:
-            self.logger.error('Failed accessing %s: %s' % (path, e.message))
+            self.logger.error('Failed accessing %s: %s' % (path, str(e)))
             # All or nothing
             retval = [] if multi else None
 
@@ -313,7 +313,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
             ret = p.wait()
         except OSError as e:
             self.logger.error('Error executing iptables-save: %s' %
-                              (e.message))
+                              (str(e)))
 
         return ret
 
@@ -328,7 +328,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
             ret = p.wait()
         except OSError as e:
             self.logger.error('Error executing iptables-restore: %s' %
-                              (e.message))
+                              (str(e)))
 
         return ret
 
@@ -351,7 +351,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
                     self.logger.error('Received return code %d from %s' +
                                       (ret, cmd))
         except OSError as e:
-            self.logger.error('Error executing %s: %s' % (cmd, e.message))
+            self.logger.error('Error executing %s: %s' % (cmd, str(e)))
 
         return rets
 
@@ -445,7 +445,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
                         ifaces.append(fields[0].strip())
         except IOError as e:
             self.logger.error('Failed to open %s to enumerate interfaces: %s' %
-                              (procfs_path, e.message))
+                              (procfs_path, str(e)))
 
         return ifaces
 
@@ -472,7 +472,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
         except IOError as e:
             self.logger.error(('Failed to open %s to save DNS ' +
                               'configuration: %s') % (resolvconf_path,
-                              e.message))
+                              str(e)))
 
         if self.old_dns:
             try:
@@ -484,7 +484,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
             except IOError as e:
                 self.logger.error(('Failed to open %s to modify DNS ' +
                                   'configuration: %s') % (resolvconf_path,
-                                  e.message))
+                                  str(e)))
 
     def linux_restore_local_dns(self):
         resolvconf_path = '/etc/resolv.conf'
@@ -496,7 +496,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
             except IOError as e:
                 self.logger.error(('Failed to open %s to restore DNS ' +
                                   'configuration: %s') % (resolvconf_path,
-                                  e.message))
+                                  str(e)))
 
     def linux_find_processes(self, names):
         """But what if a blacklisted process spawns after we call
@@ -618,7 +618,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
                                         (line.strip()))
         except IOError as e:
             self.logger.error('No such protocol/IP ver (%s) or error: %s' %
-                              (procfs_path, e.message))
+                              (procfs_path, str(e)))
 
         return inode
 
@@ -701,7 +701,7 @@ class LinUtilMixin(diverterbase.DiverterPerOSDelegate):
                 comm = f.read().strip()
         except IOError as e:
             self.pdebug(DPROCFS, 'Failed to open %s: %s' %
-                        (procfs_path, e.message))
+                        (procfs_path, str(e)))
         return comm
 
     def linux_get_pid_comm_by_endpoint(self, ipver, proto_name, ip, port):

--- a/fakenet/listeners/ProxyListener.py
+++ b/fakenet/listeners/ProxyListener.py
@@ -122,7 +122,7 @@ class ThreadedTCPClientSocket(threading.Thread):
             return new_sport
 
         except Exception as e:
-            self.logger.debug('Listener socket exception while attempting connection %s' % e.message)
+            self.logger.debug('Listener socket exception while attempting connection %s' % str(e))
 
         return None
 
@@ -143,7 +143,7 @@ class ThreadedTCPClientSocket(threading.Thread):
                         self.sock.close()
                         sys.exit(1)
         except Exception as e:
-            self.logger.debug('Listener socket exception %s' % e.message)
+            self.logger.debug('Listener socket exception %s' % str(e))
 
 class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     daemon_threads = True
@@ -210,7 +210,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
             self.server.logger.debug('%s', '-'*80,)
 
         except Exception as e:
-            self.server.logger.warning('recv() error: %s' % e.message)
+            self.server.logger.warning('recv() error: %s' % str(e))
         
         # Is the pkt ssl encrypted?
         # Using a str here instead of bool to match the format returned by


### PR DESCRIPTION
The error identified in #166 is caused when attempting to log `e.message`, however `e` does not actually have an attribute `message`. This PR removes the `.message` from the call to `e`, resolving the issue. Solution here is originally credited to the author of the issue.