### PR TITLE
CI: Format codebase with black and add black to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3
+      - name: Install dependencies
+        run: pip install black==25.*
+      - name: Run black
+        run: black --line-length=120 --check --diff .

--- a/fakenet/configs/CustomProviderExample.py
+++ b/fakenet/configs/CustomProviderExample.py
@@ -2,6 +2,7 @@
 
 import socket
 
+
 # To read about customizing HTTP responses, see docs/CustomResponse.md
 def HandleRequest(req, method, post_data=None):
     """Sample dynamic HTTP response handler.
@@ -16,21 +17,21 @@ def HandleRequest(req, method, post_data=None):
         The HTTP post data received by calling `rfile.read()` against the
         BaseHTTPRequestHandler that received the request.
     """
-    response = b'Ahoy\r\n'
+    response = b"Ahoy\r\n"
 
-    if method == 'GET':
+    if method == "GET":
         req.send_response(200)
-        req.send_header('Content-Length', len(response))
+        req.send_header("Content-Length", len(response))
         req.end_headers()
         req.wfile.write(response)
 
-    elif method == 'POST':
+    elif method == "POST":
         req.send_response(200)
-        req.send_header('Content-Length', len(response))
+        req.send_header("Content-Length", len(response))
         req.end_headers()
         req.wfile.write(response)
 
-    elif method == 'HEAD':
+    elif method == "HEAD":
         req.send_response(200)
         req.end_headers()
 
@@ -53,7 +54,7 @@ def HandleTcp(sock):
         if not data:
             break
 
-        resp = input('\nEnter a response for the TCP client: ')
+        resp = input("\nEnter a response for the TCP client: ")
         sock.sendall(resp.encode())
 
 
@@ -70,5 +71,5 @@ def HandleUdp(sock, data, addr):
         The host and port of the remote peer
     """
     if data:
-        resp = input('\nEnter a response for the UDP client: ')
+        resp = input("\nEnter a response for the UDP client: ")
         sock.sendto(resp.encode(), addr)

--- a/fakenet/diverters/debuglevels.py
+++ b/fakenet/diverters/debuglevels.py
@@ -1,44 +1,44 @@
 # Copyright 2025 Google LLC
 
 # Debug print levels for fine-grained debug trace output control
-DNFQUEUE = (1 << 0)     # netfilterqueue
-DGENPKT = (1 << 1)      # Generic packet handling
-DGENPKTV = (1 << 2)     # Generic packet handling with TCP analysis
-DCB = (1 << 3)          # Packet handlign callbacks
-DPROCFS = (1 << 4)      # procfs
-DIPTBLS = (1 << 5)      # iptables
-DNONLOC = (1 << 6)      # Nonlocal-destined datagrams
-DDPF = (1 << 7)         # DPF (Dynamic Port Forwarding)
-DDPFV = (1 << 8)        # DPF (Dynamic Port Forwarding) Verbose
-DIPNAT = (1 << 9)       # IP redirection for nonlocal-destined datagrams
-DMANGLE = (1 << 10)     # Packet mangling
-DPCAP = (1 << 11)       # Pcap write logic
-DIGN = (1 << 12)        # Packet redirect ignore conditions
-DFTP = (1 << 13)        # FTP checks
-DMISC = (1 << 27)       # Miscellaneous
+DNFQUEUE = 1 << 0  # netfilterqueue
+DGENPKT = 1 << 1  # Generic packet handling
+DGENPKTV = 1 << 2  # Generic packet handling with TCP analysis
+DCB = 1 << 3  # Packet handlign callbacks
+DPROCFS = 1 << 4  # procfs
+DIPTBLS = 1 << 5  # iptables
+DNONLOC = 1 << 6  # Nonlocal-destined datagrams
+DDPF = 1 << 7  # DPF (Dynamic Port Forwarding)
+DDPFV = 1 << 8  # DPF (Dynamic Port Forwarding) Verbose
+DIPNAT = 1 << 9  # IP redirection for nonlocal-destined datagrams
+DMANGLE = 1 << 10  # Packet mangling
+DPCAP = 1 << 11  # Pcap write logic
+DIGN = 1 << 12  # Packet redirect ignore conditions
+DFTP = 1 << 13  # FTP checks
+DMISC = 1 << 27  # Miscellaneous
 
-DCOMP = 0x0fffffff      # Component mask
-DFLAG = 0xf0000000      # Flag mask
-DEVERY = 0x0fffffff     # Log everything, low verbosity
-DEVERY2 = 0x8fffffff    # Log everything, complete verbosity
+DCOMP = 0x0FFFFFFF  # Component mask
+DFLAG = 0xF0000000  # Flag mask
+DEVERY = 0x0FFFFFFF  # Log everything, low verbosity
+DEVERY2 = 0x8FFFFFFF  # Log everything, complete verbosity
 
 DLABELS = {
-    DNFQUEUE: 'NFQUEUE',
-    DGENPKT: 'GENPKT',
-    DGENPKTV: 'GENPKTV',
-    DCB: 'CB',
-    DPROCFS: 'PROCFS',
-    DIPTBLS: 'IPTABLES',
-    DNONLOC: 'NONLOC',
-    DDPF: 'DPF',
-    DDPFV: 'DPFV',
-    DIPNAT: 'IPNAT',
-    DMANGLE: 'MANGLE',
-    DPCAP: 'PCAP',
-    DIGN: 'IGN',
-    DFTP: 'FTP',
-    DIGN | DFTP: 'IGN-FTP',
-    DMISC: 'MISC',
+    DNFQUEUE: "NFQUEUE",
+    DGENPKT: "GENPKT",
+    DGENPKTV: "GENPKTV",
+    DCB: "CB",
+    DPROCFS: "PROCFS",
+    DIPTBLS: "IPTABLES",
+    DNONLOC: "NONLOC",
+    DDPF: "DPF",
+    DDPFV: "DPFV",
+    DIPNAT: "IPNAT",
+    DMANGLE: "MANGLE",
+    DPCAP: "PCAP",
+    DIGN: "IGN",
+    DFTP: "FTP",
+    DIGN | DFTP: "IGN-FTP",
+    DMISC: "MISC",
 }
 
 DLABELS_INV = {v.upper(): k for k, v in DLABELS.items()}

--- a/fakenet/diverters/diverterbase.py
+++ b/fakenet/diverters/diverterbase.py
@@ -38,8 +38,7 @@ class DivertParms(object):
 
     @property
     def is_loopback0(self):
-        return (self.pkt.src_ip0 == self.pkt.dst_ip0 ==
-                self.diverter.loopback_ip)
+        return self.pkt.src_ip0 == self.pkt.dst_ip0 == self.diverter.loopback_ip
 
     @property
     def is_loopback(self):
@@ -53,8 +52,7 @@ class DivertParms(object):
         Returns:
             True if dport corresponds to hidden listener, else False
         """
-        return self.diverter.listener_ports.isHidden(self.pkt.proto,
-                                                     self.pkt.dport)
+        return self.diverter.listener_ports.isHidden(self.pkt.proto, self.pkt.dport)
 
     @property
     def src_local(self):
@@ -72,8 +70,7 @@ class DivertParms(object):
         Returns:
             True if sport is bound by FakeNet-NG, else False
         """
-        return self.diverter.listener_ports.isListener(self.pkt.proto,
-                                                       self.pkt.sport)
+        return self.diverter.listener_ports.isListener(self.pkt.proto, self.pkt.sport)
 
     @property
     def dport_bound(self):
@@ -82,8 +79,7 @@ class DivertParms(object):
         Returns:
             True if dport is bound by FakeNet-NG, else False
         """
-        return self.diverter.listener_ports.isListener(self.pkt.proto,
-                                                       self.pkt.dport)
+        return self.diverter.listener_ports.isListener(self.pkt.proto, self.pkt.dport)
 
     @property
     def first_packet_new_session(self):
@@ -98,8 +94,8 @@ class DivertParms(object):
         if session is None:
             return True
 
-        return not ((session.dst_ip, session.dport) ==
-                        (self.pkt.dst_ip, self.pkt.dport))
+        return not ((session.dst_ip, session.dport) == (self.pkt.dst_ip, self.pkt.dport))
+
 
 class DiverterPerOSDelegate(object, metaclass=abc.ABCMeta):
     """Delegate class for OS-specific methods that FakeNet-NG implementors must
@@ -236,6 +232,7 @@ class ListenerMeta(object):
     group. Accessors are in ListenerPorts for querying the collection for
     listeners and their attributes.
     """
+
     def __init__(self, proto, port, hidden=False):
         self.proto = proto
         self.port = port
@@ -248,7 +245,7 @@ class ListenerMeta(object):
 
     def _splitBlackWhiteList(self, configtext):
         """Return list from comma-separated config line."""
-        return [item.strip() for item in configtext.split(',')]
+        return [item.strip() for item in configtext.split(",")]
 
     def _validateBlackWhite(self):
         """Validate that only a black or a white list of either type (host or
@@ -258,12 +255,12 @@ class ListenerMeta(object):
             Raises ListenerBlackWhiteList if invalid
         """
         msg = None
-        fmt = 'Cannot specify both %s blacklist and whitelist for port %d'
+        fmt = "Cannot specify both %s blacklist and whitelist for port %d"
         if self.proc_wl and self.proc_bl:
-            msg = fmt % ('process', self.port)
+            msg = fmt % ("process", self.port)
             self.proc_wl = self.proc_bl = None
         elif self.host_wl and self.host_bl:
-            msg = fmt % ('host', self.port)
+            msg = fmt % ("host", self.port)
             self.host_wl = self.host_bl = None
         if msg:
             raise ListenerBlackWhiteList(msg)
@@ -306,8 +303,8 @@ class ListenerPorts(object):
 
     def __init__(self):
         """Initialize dictionary of dictionaries:
-            protocol name => dict
-                portno => ListenerMeta
+        protocol name => dict
+            portno => ListenerMeta
         """
         self.protos = {}
 
@@ -320,8 +317,7 @@ class ListenerPorts(object):
             self.protos[proto] = {}
 
         if port in self.protos[proto]:
-            raise ListenerAlreadyBoundThere(
-                'Listener already bound to %s port %s' % (proto, port))
+            raise ListenerAlreadyBoundThere("Listener already bound to %s port %s" % (proto, port))
 
         self.protos[proto][port] = listener
 
@@ -394,7 +390,7 @@ class ListenerPorts(object):
         """
         if not blacklist:
             return False
-        return (thing in blacklist)
+        return thing in blacklist
 
     def isProcessWhiteListMiss(self, proto, port, proc):
         """Check if proc is OUTSIDE the process WHITElist for a port.
@@ -465,14 +461,15 @@ class ListenerPorts(object):
         return self._isBlackListHit(host, listener.host_bl)
 
 
-class PidCommDest():
+class PidCommDest:
     """Helper for recognizing connections that were already displayed."""
+
     def __init__(self, pid, comm, proto, ip, port):
         self.pid = pid
-        self.comm = comm or 'program name unknown'
-        self.proto = proto or 'unknown protocol'
-        self.ip = ip or 'unknown IP'
-        self.port = str(port) or 'port unknown/not applicable'
+        self.comm = comm or "program name unknown"
+        self.proto = proto or "unknown protocol"
+        self.ip = ip or "unknown IP"
+        self.port = str(port) or "port unknown/not applicable"
 
     def isDistinct(self, prev, bound_ips):
         """Not quite inequality.
@@ -482,13 +479,16 @@ class PidCommDest():
         occupied by an adapter local to the system to be able to suppress
         output of these near-duplicates.
         """
-        return ((not prev) or (self.pid != prev.pid) or
-                (self.comm != prev.comm) or (self.port != prev.port) or
-                ((self.ip != prev.ip) and (self.ip not in bound_ips)))
+        return (
+            (not prev)
+            or (self.pid != prev.pid)
+            or (self.comm != prev.comm)
+            or (self.port != prev.port)
+            or ((self.ip != prev.ip) and (self.ip not in bound_ips))
+        )
 
     def __str__(self):
-        return '%s (%s) requested %s %s:%s' % (self.comm, self.pid, self.proto,
-                                               self.ip, self.port)
+        return "%s (%s) requested %s %s:%s" % (self.comm, self.pid, self.proto, self.ip, self.port)
 
 
 class DiverterBase(fnconfig.Config):
@@ -499,8 +499,7 @@ class DiverterBase(fnconfig.Config):
         stopCallback()
     """
 
-    def __init__(self, diverter_config, listeners_config, ip_addrs,
-                 logging_level=logging.INFO):
+    def __init__(self, diverter_config, listeners_config, ip_addrs, logging_level=logging.INFO):
         """Initialize the DiverterBase.
 
         TODO: Replace the sys.exit() calls from this function with exceptions
@@ -535,10 +534,10 @@ class DiverterBase(fnconfig.Config):
         self.ip_addrs = ip_addrs
 
         self.pcap = None
-        self.pcap_filename = ''
+        self.pcap_filename = ""
         self.pcap_lock = None
 
-        self.logger = logging.getLogger('Diverter')
+        self.logger = logging.getLogger("Diverter")
         self.logger.setLevel(logging_level)
 
         # Network Based Indicators
@@ -546,7 +545,7 @@ class DiverterBase(fnconfig.Config):
 
         # Index remote Process IDs for MultiHost operations
         self.remote_pid_counter = 0
-        
+
         # Maps Proxy initiated source ports to original source ports
         self.proxy_sport_to_orig_sport_map = {}
 
@@ -556,16 +555,15 @@ class DiverterBase(fnconfig.Config):
         # Rate limiting for displaying pid/comm/proto/IP/port
         self.last_conn = None
 
-        portlists = ['BlackListPortsTCP', 'BlackListPortsUDP']
-        stringlists = ['HostBlackList']
-        idlists = ['BlackListIDsICMP']
+        portlists = ["BlackListPortsTCP", "BlackListPortsUDP"]
+        stringlists = ["HostBlackList"]
+        idlists = ["BlackListIDsICMP"]
         self.configure(diverter_config, portlists, stringlists, idlists)
-        self.listeners_config = dict((k.lower(), v)
-                                     for k, v in listeners_config.items())
+        self.listeners_config = dict((k.lower(), v) for k, v in listeners_config.items())
 
         # Local IP address
         self.external_ip = socket.gethostbyname(socket.gethostname())
-        self.loopback_ip = socket.gethostbyname('localhost')
+        self.loopback_ip = socket.gethostbyname("localhost")
 
         # Sessions cache
         # NOTE: A dictionary of source ports mapped to destination address,
@@ -609,10 +607,10 @@ class DiverterBase(fnconfig.Config):
         self.default_listener = dict()
 
         # Global TCP/UDP port blacklist
-        self.blacklist_ports = {'TCP': [], 'UDP': []}
+        self.blacklist_ports = {"TCP": [], "UDP": []}
 
         # Glocal ICMP ID blacklist
-        self.blacklist_ids = {'ICMP': []}
+        self.blacklist_ids = {"ICMP": []}
 
         # Global process blacklist
         # TODO: Allow PIDs
@@ -626,18 +624,20 @@ class DiverterBase(fnconfig.Config):
         # Parse diverter config
         self.parse_diverter_config()
 
-        slists = ['DebugLevel', ]
+        slists = [
+            "DebugLevel",
+        ]
         self.reconfigure(portlists=[], stringlists=slists)
 
         dbg_lvl = 0
-        if self.is_configured('DebugLevel'):
-            for label in self.getconfigval('DebugLevel'):
+        if self.is_configured("DebugLevel"):
+            for label in self.getconfigval("DebugLevel"):
                 label = label.upper()
-                if label == 'OFF':
+                if label == "OFF":
                     dbg_lvl = 0
                     break
                 if not label in DLABELS_INV:
-                    self.logger.warning('No such DebugLevel as %s' % (label))
+                    self.logger.warning("No such DebugLevel as %s" % (label))
                 else:
                     dbg_lvl |= DLABELS_INV[label]
         self.set_debug_level(dbg_lvl, DLABELS)
@@ -647,47 +647,42 @@ class DiverterBase(fnconfig.Config):
 
         # Check active interfaces
         if not self.check_active_ethernet_adapters():
-            self.logger.critical('ERROR: No active ethernet interfaces '
-                                 'detected!')
-            self.logger.critical('         Please enable a network interface.')
+            self.logger.critical("ERROR: No active ethernet interfaces " "detected!")
+            self.logger.critical("         Please enable a network interface.")
             sys.exit(1)
 
         # Check configured ip addresses
         if not self.check_ipaddresses():
-            self.logger.critical('ERROR: No interface had IP address '
-                                 'configured!')
-            self.logger.critical('         Please configure an IP address on '
-                                 'network interface.')
+            self.logger.critical("ERROR: No interface had IP address " "configured!")
+            self.logger.critical("         Please configure an IP address on " "network interface.")
             sys.exit(1)
 
         # Check configured gateways
         gw_ok = self.check_gateways()
         if not gw_ok:
-            self.logger.warning('WARNING: No gateways configured!')
-            if self.is_set('fixgateway'):
+            self.logger.warning("WARNING: No gateways configured!")
+            if self.is_set("fixgateway"):
                 gw_ok = self.fix_gateway()
                 if not gw_ok:
-                    self.logger.warning('Cannot fix gateway')
+                    self.logger.warning("Cannot fix gateway")
 
         if not gw_ok:
-            self.logger.warning('         Please configure a default ' +
-                                'gateway or route in order to intercept ' +
-                                'external traffic.')
-            self.logger.warning('         Current interception abilities ' +
-                                'are limited to local traffic.')
+            self.logger.warning(
+                "         Please configure a default " + "gateway or route in order to intercept " + "external traffic."
+            )
+            self.logger.warning("         Current interception abilities " + "are limited to local traffic.")
 
         # Check configured DNS servers
         dns_ok = self.check_dns_servers()
         if not dns_ok:
-            self.logger.warning('WARNING: No DNS servers configured!')
-            if self.is_set('fixdns'):
+            self.logger.warning("WARNING: No DNS servers configured!")
+            if self.is_set("fixdns"):
                 dns_ok = self.fix_dns()
                 if not dns_ok:
-                    self.logger.warning('Cannot fix DNS')
+                    self.logger.warning("Cannot fix DNS")
 
         if not dns_ok:
-            self.logger.warning('         Please configure a DNS server ' +
-                                'in order to allow network resolution.')
+            self.logger.warning("         Please configure a DNS server " + "in order to allow network resolution.")
 
         # OS-specific Diverters must initialize e.g. WinDivert,
         # libnetfilter_queue, pf/alf, etc.
@@ -701,11 +696,11 @@ class DiverterBase(fnconfig.Config):
         to the already-defined (and potentially some yet-to-be-defined)
         abstract methods that handle the real OS-specific stuff.
         """
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
         return self.startCallback()
 
     def stop(self):
-        self.logger.info('Stopping...')
+        self.logger.info("Stopping...")
         self.prettyPrintNbi()
         self.generate_html_report()
         return self.stopCallback()
@@ -766,7 +761,7 @@ class DiverterBase(fnconfig.Config):
         """
         if self.pdebug_level & lvl:
             label = self.pdebug_labels.get(lvl)
-            prefix = '[' + label + '] ' if label else '[some component] '
+            prefix = "[" + label + "] " if label else "[some component] "
             self.logger.debug(prefix + str(s))
 
     def check_privileged(self):
@@ -776,9 +771,9 @@ class DiverterBase(fnconfig.Config):
             True if superuser, else False
         """
         try:
-            privileged = (os.getuid() == 0)
+            privileged = os.getuid() == 0
         except AttributeError:
-            privileged = (ctypes.windll.shell32.IsUserAnAdmin() != 0)
+            privileged = ctypes.windll.shell32.IsUserAnAdmin() != 0
 
         return privileged
 
@@ -801,40 +796,35 @@ class DiverterBase(fnconfig.Config):
         # Populate diverter ports and process filters from the configuration
         for listener_name, listener_config in listeners_config.items():
 
-            if 'port' in listener_config:
+            if "port" in listener_config:
 
-                port = int(listener_config['port'])
+                port = int(listener_config["port"])
 
-                hidden = (listener_config.get('hidden', 'false').lower() ==
-                          'true')
+                hidden = listener_config.get("hidden", "false").lower() == "true"
 
-                if not 'protocol' in listener_config:
-                    self.logger.error('ERROR: Protocol not defined for ' +
-                                      'listener %s', listener_name)
+                if not "protocol" in listener_config:
+                    self.logger.error("ERROR: Protocol not defined for " + "listener %s", listener_name)
                     sys.exit(1)
 
-                protocol = listener_config['protocol'].upper()
+                protocol = listener_config["protocol"].upper()
 
-                if not protocol in ['TCP', 'UDP']:
-                    self.logger.error('ERROR: Invalid protocol %s for ' +
-                                      'listener %s', protocol, listener_name)
+                if not protocol in ["TCP", "UDP"]:
+                    self.logger.error("ERROR: Invalid protocol %s for " + "listener %s", protocol, listener_name)
                     sys.exit(1)
 
                 listener = ListenerMeta(protocol, port, hidden)
 
                 ###############################################################
                 # Process filtering configuration
-                if ('processwhitelist' in listener_config and
-                        'processblacklist' in listener_config):
-                    self.logger.error('ERROR: Listener can\'t have both ' +
-                                      'process whitelist and blacklist.')
+                if "processwhitelist" in listener_config and "processblacklist" in listener_config:
+                    self.logger.error("ERROR: Listener can't have both " + "process whitelist and blacklist.")
                     sys.exit(1)
 
-                elif 'processwhitelist' in listener_config:
+                elif "processwhitelist" in listener_config:
 
-                    self.logger.debug('Process whitelist:')
+                    self.logger.debug("Process whitelist:")
 
-                    whitelist = listener_config['processwhitelist']
+                    whitelist = listener_config["processwhitelist"]
                     listener.setProcessWhitelist(whitelist)
 
                     # for port in self.port_process_whitelist[protocol]:
@@ -842,10 +832,10 @@ class DiverterBase(fnconfig.Config):
                     #                       port, protocol, ', '.join(
                     #         self.port_process_whitelist[protocol][port]))
 
-                elif 'processblacklist' in listener_config:
-                    self.logger.debug('Process blacklist:')
+                elif "processblacklist" in listener_config:
+                    self.logger.debug("Process blacklist:")
 
-                    blacklist = listener_config['processblacklist']
+                    blacklist = listener_config["processblacklist"]
                     listener.setProcessBlacklist(blacklist)
 
                     # for port in self.port_process_blacklist[protocol]:
@@ -855,15 +845,13 @@ class DiverterBase(fnconfig.Config):
 
                 ###############################################################
                 # Host filtering configuration
-                if ('hostwhitelist' in listener_config and
-                        'hostblacklist' in listener_config):
-                    self.logger.error('ERROR: Listener can\'t have both ' +
-                                      'host whitelist and blacklist.')
+                if "hostwhitelist" in listener_config and "hostblacklist" in listener_config:
+                    self.logger.error("ERROR: Listener can't have both " + "host whitelist and blacklist.")
                     sys.exit(1)
 
-                elif 'hostwhitelist' in listener_config:
-                    self.logger.debug('Host whitelist:')
-                    host_whitelist = listener_config['hostwhitelist']
+                elif "hostwhitelist" in listener_config:
+                    self.logger.debug("Host whitelist:")
+                    host_whitelist = listener_config["hostwhitelist"]
                     listener.setHostWhitelist(host_whitelist)
 
                     # for port in self.port_host_whitelist[protocol]:
@@ -871,9 +859,9 @@ class DiverterBase(fnconfig.Config):
                     #                       protocol, ', '.join(
                     #         self.port_host_whitelist[protocol][port]))
 
-                elif 'hostblacklist' in listener_config:
-                    self.logger.debug('Host blacklist:')
-                    host_blacklist = listener_config['hostblacklist']
+                elif "hostblacklist" in listener_config:
+                    self.logger.debug("Host blacklist:")
+                    host_blacklist = listener_config["hostblacklist"]
                     listener.setHostBlacklist(host_blacklist)
 
                     # for port in self.port_host_blacklist[protocol]:
@@ -886,26 +874,24 @@ class DiverterBase(fnconfig.Config):
 
                 ###############################################################
                 # Execute command configuration
-                if 'executecmd' in listener_config:
-                    template = listener_config['executecmd'].strip()
+                if "executecmd" in listener_config:
+                    template = listener_config["executecmd"].strip()
 
                     # Would prefer not to get into the middle of a debug
                     # session and learn that a typo has ruined the day, so we
                     # test beforehand to make sure all the user-specified
                     # insertion strings are valid.
-                    test = self._build_cmd(template, 0, 'test', '1.2.3.4',
-                                           12345, '4.3.2.1', port)
+                    test = self._build_cmd(template, 0, "test", "1.2.3.4", 12345, "4.3.2.1", port)
                     if not test:
-                        self.logger.error(('Terminating due to incorrectly ' +
-                                          'configured ExecuteCmd for ' +
-                                          'listener %s') % (listener_name))
+                        self.logger.error(
+                            ("Terminating due to incorrectly " + "configured ExecuteCmd for " + "listener %s")
+                            % (listener_name)
+                        )
                         sys.exit(1)
 
                     listener.setExecuteCmd(template)
 
-                    self.logger.debug('Port %d (%s) ExecuteCmd: %s', port,
-                                      protocol,
-                                      template)
+                    self.logger.debug("Port %d (%s) ExecuteCmd: %s", port, protocol, template)
 
     def build_cmd(self, pkt, pid, comm):
         """Retrieve the ExecuteCmd directive if applicable and build the
@@ -923,8 +909,7 @@ class DiverterBase(fnconfig.Config):
 
         template = self.listener_ports.getExecuteCmd(pkt.proto, pkt.dport)
         if template:
-            cmd = self._build_cmd(template, pid, comm, pkt.src_ip, pkt.sport,
-                                  pkt.dst_ip, pkt.dport)
+            cmd = self._build_cmd(template, pid, comm, pkt.src_ip, pkt.sport, pkt.dst_ip, pkt.dport)
 
         return cmd
 
@@ -958,11 +943,12 @@ class DiverterBase(fnconfig.Config):
                 src_addr=str(src_ip),
                 src_port=str(sport),
                 dst_addr=str(dst_ip),
-                dst_port=str(dport))
+                dst_port=str(dport),
+            )
         except KeyError as e:
-            self.logger.error(('Failed to build ExecuteCmd for port %d due ' +
-                              'to erroneous format key: %s') %
-                              (dport, str(e)))
+            self.logger.error(
+                ("Failed to build ExecuteCmd for port %d due " + "to erroneous format key: %s") % (dport, str(e))
+            )
 
         return cmd
 
@@ -997,15 +983,11 @@ class DiverterBase(fnconfig.Config):
         preexec = None if self.running_on_windows else ign_sigint
 
         try:
-            pid = subprocess.Popen(execute_cmd, creationflags=cflags,
-                                   shell=shl,
-                                   close_fds=cfds,
-                                   preexec_fn=preexec).pid
+            pid = subprocess.Popen(execute_cmd, creationflags=cflags, shell=shl, close_fds=cfds, preexec_fn=preexec).pid
         except Exception as e:
-            self.logger.error('Exception of type %s' % (str(type(e))))
-            self.logger.error('Error: Failed to execute command: %s',
-                              execute_cmd)
-            self.logger.error('       %s', e)
+            self.logger.error("Exception of type %s" % (str(type(e))))
+            self.logger.error("Error: Failed to execute command: %s", execute_cmd)
+            self.logger.error("       %s", e)
         else:
             return pid
 
@@ -1021,123 +1003,117 @@ class DiverterBase(fnconfig.Config):
             None
         """
         # SingleHost vs MultiHost mode
-        self.network_mode = 'SingleHost'  # Default
+        self.network_mode = "SingleHost"  # Default
         self.single_host_mode = True
-        if self.is_configured('networkmode'):
-            self.network_mode = self.getconfigval('networkmode')
-            available_modes = ['singlehost', 'multihost']
+        if self.is_configured("networkmode"):
+            self.network_mode = self.getconfigval("networkmode")
+            available_modes = ["singlehost", "multihost"]
 
             # Constrain argument values
             if self.network_mode.lower() not in available_modes:
-                self.logger.error('NetworkMode must be one of %s' %
-                                  (available_modes))
+                self.logger.error("NetworkMode must be one of %s" % (available_modes))
                 sys.exit(1)
 
             # Adjust previously assumed mode if operator specifies MultiHost
-            if self.network_mode.lower() == 'multihost':
+            if self.network_mode.lower() == "multihost":
                 self.single_host_mode = False
 
-        if (self.getconfigval('processwhitelist') and
-                self.getconfigval('processblacklist')):
-            self.logger.error('ERROR: Diverter can\'t have both process ' +
-                              'whitelist and blacklist.')
+        if self.getconfigval("processwhitelist") and self.getconfigval("processblacklist"):
+            self.logger.error("ERROR: Diverter can't have both process " + "whitelist and blacklist.")
             sys.exit(1)
 
-        if self.is_set('dumppackets'):
-            self.pcap_filename = '%s_%s.pcap' % (self.getconfigval(
-                'dumppacketsfileprefix', 'packets'),
-                time.strftime('%Y%m%d_%H%M%S'))
-            self.logger.info('Capturing traffic to %s', self.pcap_filename)
-            self.pcap = dpkt.pcap.Writer(open(self.pcap_filename, 'wb'),
-                                         linktype=dpkt.pcap.DLT_RAW)
+        if self.is_set("dumppackets"):
+            self.pcap_filename = "%s_%s.pcap" % (
+                self.getconfigval("dumppacketsfileprefix", "packets"),
+                time.strftime("%Y%m%d_%H%M%S"),
+            )
+            self.logger.info("Capturing traffic to %s", self.pcap_filename)
+            self.pcap = dpkt.pcap.Writer(open(self.pcap_filename, "wb"), linktype=dpkt.pcap.DLT_RAW)
             self.pcap_lock = threading.Lock()
 
         # Do not redirect blacklisted processes
-        if self.is_configured('processblacklist'):
-            self.blacklist_processes = [process.strip() for process in
-                self.getconfigval('processblacklist').split(',')]
-            self.logger.debug('Blacklisted processes: %s', ', '.join(
-                [str(p) for p in self.blacklist_processes]))
+        if self.is_configured("processblacklist"):
+            self.blacklist_processes = [process.strip() for process in self.getconfigval("processblacklist").split(",")]
+            self.logger.debug("Blacklisted processes: %s", ", ".join([str(p) for p in self.blacklist_processes]))
             if self.logger.level == logging.INFO:
-                self.logger.info('Hiding logs from blacklisted processes')
+                self.logger.info("Hiding logs from blacklisted processes")
 
         # Only redirect whitelisted processes
-        if self.is_configured('processwhitelist'):
-            self.whitelist_processes = [process.strip() for process in
-                self.getconfigval('processwhitelist').split(',')]
-            self.logger.debug('Whitelisted processes: %s', ', '.join(
-                [str(p) for p in self.whitelist_processes]))
+        if self.is_configured("processwhitelist"):
+            self.whitelist_processes = [process.strip() for process in self.getconfigval("processwhitelist").split(",")]
+            self.logger.debug("Whitelisted processes: %s", ", ".join([str(p) for p in self.whitelist_processes]))
 
         # Do not redirect blacklisted hosts
-        if self.is_configured('hostblacklist'):
-            self.blacklist_hosts = self.getconfigval('hostblacklist')
-            self.logger.debug('Blacklisted hosts: %s', ', '.join(
-                [str(p) for p in self.getconfigval('hostblacklist')]))
+        if self.is_configured("hostblacklist"):
+            self.blacklist_hosts = self.getconfigval("hostblacklist")
+            self.logger.debug("Blacklisted hosts: %s", ", ".join([str(p) for p in self.getconfigval("hostblacklist")]))
 
         # Redirect all traffic
-        self.default_listener = {'TCP': None, 'UDP': None}
-        if self.is_set('redirectalltraffic'):
-            if self.is_unconfigured('defaulttcplistener'):
-                self.logger.error('ERROR: No default TCP listener specified ' +
-                                  'in the configuration.')
+        self.default_listener = {"TCP": None, "UDP": None}
+        if self.is_set("redirectalltraffic"):
+            if self.is_unconfigured("defaulttcplistener"):
+                self.logger.error("ERROR: No default TCP listener specified " + "in the configuration.")
                 sys.exit(1)
 
-            elif self.is_unconfigured('defaultudplistener'):
-                self.logger.error('ERROR: No default UDP listener specified ' +
-                                  'in the configuration.')
+            elif self.is_unconfigured("defaultudplistener"):
+                self.logger.error("ERROR: No default UDP listener specified " + "in the configuration.")
                 sys.exit(1)
 
-            elif not (self.getconfigval('defaulttcplistener').lower() in
-                      self.listeners_config):
-                self.logger.error('ERROR: No configuration exists for ' +
-                                  'default TCP listener %s',
-                                  self.getconfigval('defaulttcplistener'))
+            elif not (self.getconfigval("defaulttcplistener").lower() in self.listeners_config):
+                self.logger.error(
+                    "ERROR: No configuration exists for " + "default TCP listener %s",
+                    self.getconfigval("defaulttcplistener"),
+                )
                 sys.exit(1)
 
-            elif not (self.getconfigval('defaultudplistener').lower() in
-                      self.listeners_config):
-                self.logger.error('ERROR: No configuration exists for ' +
-                                  'default UDP listener %s',
-                                  self.getconfigval('defaultudplistener'))
+            elif not (self.getconfigval("defaultudplistener").lower() in self.listeners_config):
+                self.logger.error(
+                    "ERROR: No configuration exists for " + "default UDP listener %s",
+                    self.getconfigval("defaultudplistener"),
+                )
                 sys.exit(1)
 
             else:
-                default_listener = self.getconfigval('defaulttcplistener').lower()
-                default_port = self.listeners_config[default_listener]['port']
-                self.default_listener['TCP'] = int(default_port)
-                self.logger.debug('Using default listener %s on port %d',
-                                  self.getconfigval('defaulttcplistener').lower(),
-                                  self.default_listener['TCP'])
+                default_listener = self.getconfigval("defaulttcplistener").lower()
+                default_port = self.listeners_config[default_listener]["port"]
+                self.default_listener["TCP"] = int(default_port)
+                self.logger.debug(
+                    "Using default listener %s on port %d",
+                    self.getconfigval("defaulttcplistener").lower(),
+                    self.default_listener["TCP"],
+                )
 
-                default_listener = self.getconfigval('defaultudplistener').lower()
-                default_port = self.listeners_config[default_listener]['port']
-                self.default_listener['UDP'] = int(default_port)
-                self.logger.debug('Using default listener %s on port %d',
-                                  self.getconfigval('defaultudplistener').lower(),
-                                  self.default_listener['UDP'])
+                default_listener = self.getconfigval("defaultudplistener").lower()
+                default_port = self.listeners_config[default_listener]["port"]
+                self.default_listener["UDP"] = int(default_port)
+                self.logger.debug(
+                    "Using default listener %s on port %d",
+                    self.getconfigval("defaultudplistener").lower(),
+                    self.default_listener["UDP"],
+                )
 
             # Re-marshall these into a readily usable form...
 
             # Do not redirect blacklisted TCP ports
-            if self.is_configured('blacklistportstcp'):
-                self.blacklist_ports['TCP'] = \
-                    self.getconfigval('blacklistportstcp')
-                self.logger.debug('Blacklisted TCP ports: %s', ', '.join(
-                    [str(p) for p in self.getconfigval('BlackListPortsTCP')]))
+            if self.is_configured("blacklistportstcp"):
+                self.blacklist_ports["TCP"] = self.getconfigval("blacklistportstcp")
+                self.logger.debug(
+                    "Blacklisted TCP ports: %s", ", ".join([str(p) for p in self.getconfigval("BlackListPortsTCP")])
+                )
 
             # Do not redirect blacklisted UDP ports
-            if self.is_configured('blacklistportsudp'):
-                self.blacklist_ports['UDP'] = \
-                    self.getconfigval('blacklistportsudp')
-                self.logger.debug('Blacklisted UDP ports: %s', ', '.join(
-                    [str(p) for p in self.getconfigval('BlackListPortsUDP')]))
+            if self.is_configured("blacklistportsudp"):
+                self.blacklist_ports["UDP"] = self.getconfigval("blacklistportsudp")
+                self.logger.debug(
+                    "Blacklisted UDP ports: %s", ", ".join([str(p) for p in self.getconfigval("BlackListPortsUDP")])
+                )
 
             # Do not redirect blacklisted ICMP IDs
-            if self.is_configured('blacklistidsicmp'):
-                self.blacklist_ids['ICMP'] = \
-                    self.getconfigval('blacklistidsicmp')
-                self.logger.debug('Blacklisted ICMP IDs: %s', ', '.join(
-                    [str(c) for c in self.getconfigval('BlackListIDsICMP')]))
+            if self.is_configured("blacklistidsicmp"):
+                self.blacklist_ids["ICMP"] = self.getconfigval("blacklistidsicmp")
+                self.logger.debug(
+                    "Blacklisted ICMP IDs: %s", ", ".join([str(c) for c in self.getconfigval("BlackListIDsICMP")])
+                )
 
     def write_pcap(self, pkt):
         """Writes a packet to the pcap.
@@ -1153,9 +1129,8 @@ class DiverterBase(fnconfig.Config):
         """
         if self.pcap and self.pcap_lock:
             with self.pcap_lock:
-                mangled = 'mangled' if pkt.mangled else 'initial'
-                self.pdebug(DPCAP, 'Writing %s packet %s' %
-                            (mangled, pkt.hdrToStr2()))
+                mangled = "mangled" if pkt.mangled else "initial"
+                self.pdebug(DPCAP, "Writing %s packet %s" % (mangled, pkt.hdrToStr2()))
                 self.pcap.writepkt(pkt.octets)
 
     def handle_pkt(self, pkt, callbacks3, callbacks4):
@@ -1199,9 +1174,9 @@ class DiverterBase(fnconfig.Config):
         no_further_processing = False
 
         if pkt.ipver is None:
-            self.logger.warning('%s: Failed to parse IP packet' % (pkt.label))
+            self.logger.warning("%s: Failed to parse IP packet" % (pkt.label))
         else:
-            self.pdebug(DGENPKT, '%s %s' % (pkt.label, pkt.hdrToStr()))
+            self.pdebug(DGENPKT, "%s %s" % (pkt.label, pkt.hdrToStr()))
 
             crit = DivertParms(self, pkt)
 
@@ -1219,25 +1194,23 @@ class DiverterBase(fnconfig.Config):
                     # process, messages are logged with level DEBUG. Executing
                     # FakeNet in the verbose mode will print these logs
                     is_process_blacklisted, _, _ = self.isProcessBlackListed(
-                                                        pkt.proto,
-                                                        process_name=comm,
-                                                        dport=pkt.dport0
-                                                    )
+                        pkt.proto, process_name=comm, dport=pkt.dport0
+                    )
                     if is_process_blacklisted:
-                        self.logger.debug('%s' % (str(pc)))
+                        self.logger.debug("%s" % (str(pc)))
                     else:
-                        self.logger.info('%s' % (str(pc)))
+                        self.logger.info("%s" % (str(pc)))
 
             # 2: Call layer 3 (network) callbacks
             for cb in callbacks3:
                 # These debug outputs are useful for figuring out which
                 # callback is responsible for an exception that was masked by
                 # python-netfilterqueue's global callback.
-                self.pdebug(DCB, 'Calling %s' % (cb))
+                self.pdebug(DCB, "Calling %s" % (cb))
 
                 cb(crit, pkt)
 
-                self.pdebug(DCB, '%s finished' % (cb))
+                self.pdebug(DCB, "%s finished" % (cb))
 
             if pkt.proto:
 
@@ -1246,9 +1219,8 @@ class DiverterBase(fnconfig.Config):
                     # fall where they may. This behavior now applies to all
                     # Diverters.
                     if crit.is_loopback:
-                        self.logger.debug('Ignoring loopback packet')
-                        self.logger.debug('  %s:%d -> %s:%d', pkt.src_ip,
-                                          pkt.sport, pkt.dst_ip, pkt.dport)
+                        self.logger.debug("Ignoring loopback packet")
+                        self.logger.debug("  %s:%d -> %s:%d", pkt.src_ip, pkt.sport, pkt.dst_ip, pkt.dport)
                         no_further_processing = True
 
                     # 3: Layer 4 (Transport layer) callbacks
@@ -1258,15 +1230,14 @@ class DiverterBase(fnconfig.Config):
                             # which callback is responsible for an exception
                             # that was masked by python-netfilterqueue's global
                             # callback.
-                            self.pdebug(DCB, 'Calling %s' % (cb))
+                            self.pdebug(DCB, "Calling %s" % (cb))
 
                             cb(crit, pkt, pid, comm)
 
-                            self.pdebug(DCB, '%s finished' % (cb))
+                            self.pdebug(DCB, "%s finished" % (cb))
 
             else:
-                self.pdebug(DGENPKT, '%s: Not handling protocol %s' %
-                                     (pkt.label, pkt.proto))
+                self.pdebug(DGENPKT, "%s: Not handling protocol %s" % (pkt.label, pkt.proto))
 
         # 4: Double write mangled packets to represent changes made by
         # FakeNet-NG while still allowing SSL decoding with the old packets
@@ -1284,10 +1255,10 @@ class DiverterBase(fnconfig.Config):
         Returns:
             A str containing the log line
         """
-        logline = ''
+        logline = ""
 
-        if pkt.proto == 'UDP':
-            fmt = '| {label} {proto} | {pid:>6} | {comm:<8} | {src:>15}:{sport:<5} | {dst:>15}:{dport:<5} | {length:>5} | {flags:<11} | {seqack:<35} |'
+        if pkt.proto == "UDP":
+            fmt = "| {label} {proto} | {pid:>6} | {comm:<8} | {src:>15}:{sport:<5} | {dst:>15}:{dport:<5} | {length:>5} | {flags:<11} | {seqack:<35} |"
             logline = fmt.format(
                 label=pkt.label,
                 proto=pkt.proto,
@@ -1298,28 +1269,28 @@ class DiverterBase(fnconfig.Config):
                 dst=pkt.dst_ip,
                 dport=pkt.dport,
                 length=len(pkt),
-                flags='',
-                seqack='',
-                )
+                flags="",
+                seqack="",
+            )
 
-        elif pkt.proto == 'TCP':
+        elif pkt.proto == "TCP":
             tcp = pkt._hdr.data
 
-            sa = 'Seq=%d, Ack=%d' % (tcp.seq, tcp.ack)
+            sa = "Seq=%d, Ack=%d" % (tcp.seq, tcp.ack)
 
             f = []
             if (tcp.flags & dpkt.tcp.TH_RST) != 0:
-                f.append('RST')
+                f.append("RST")
             if (tcp.flags & dpkt.tcp.TH_SYN) != 0:
-                f.append('SYN')
+                f.append("SYN")
             if (tcp.flags & dpkt.tcp.TH_ACK) != 0:
-                f.append('ACK')
+                f.append("ACK")
             if (tcp.flags & dpkt.tcp.TH_FIN) != 0:
-                f.append('FIN')
+                f.append("FIN")
             if (tcp.flags & dpkt.tcp.TH_PUSH) != 0:
-                f.append('PSH')
+                f.append("PSH")
 
-            fmt = '| {label} {proto} | {pid:>6} | {comm:<8} | {src:>15}:{sport:<5} | {dst:>15}:{dport:<5} | {length:>5} | {flags:<11} | {seqack:<35} |'
+            fmt = "| {label} {proto} | {pid:>6} | {comm:<8} | {src:>15}:{sport:<5} | {dst:>15}:{dport:<5} | {length:>5} | {flags:<11} | {seqack:<35} |"
             logline = fmt.format(
                 label=pkt.label,
                 proto=pkt.proto,
@@ -1330,14 +1301,14 @@ class DiverterBase(fnconfig.Config):
                 dst=pkt.dst_ip,
                 dport=pkt.dport,
                 length=len(pkt),
-                flags=','.join(f),
+                flags=",".join(f),
                 seqack=sa,
-                )
+            )
         else:
-            fmt = '| {label} {proto} | {pid:>6} | {comm:<8} | {src:>15}:{sport:<5} | {dst:>15}:{dport:<5} | {length:>5} | {flags:<11} | {seqack:<35} |'
+            fmt = "| {label} {proto} | {pid:>6} | {comm:<8} | {src:>15}:{sport:<5} | {dst:>15}:{dport:<5} | {length:>5} | {flags:<11} | {seqack:<35} |"
             logline = fmt.format(
                 label=pkt.label,
-                proto='UNK',
+                proto="UNK",
                 pid=str(pid),
                 comm=str(comm),
                 src=str(pkt.src_ip),
@@ -1345,9 +1316,9 @@ class DiverterBase(fnconfig.Config):
                 dst=str(pkt.dst_ip),
                 dport=str(pkt.dport),
                 length=len(pkt),
-                flags='',
-                seqack='',
-                )
+                flags="",
+                seqack="",
+            )
         return logline
 
     def check_should_ignore(self, pkt, pid, comm):
@@ -1370,9 +1341,8 @@ class DiverterBase(fnconfig.Config):
         dst_ip = pkt.dst_ip0
         dport = pkt.dport0
 
-        if not self.is_set('redirectalltraffic'):
-            self.pdebug(DIGN, 'Ignoring %s packet %s' %
-                        (pkt.proto, pkt.hdrToStr()))
+        if not self.is_set("redirectalltraffic"):
+            self.pdebug(DIGN, "Ignoring %s packet %s" % (pkt.proto, pkt.hdrToStr()))
             return True
 
         # SingleHost mode checks
@@ -1380,41 +1350,39 @@ class DiverterBase(fnconfig.Config):
             if comm:
                 # Check process blacklist
                 if comm in self.blacklist_processes:
-                    self.pdebug(DIGN, ('Ignoring %s packet from process %s ' +
-                                'in the process blacklist.') % (pkt.proto,
-                                comm))
-                    self.pdebug(DIGN, '  %s' %
-                                (pkt.hdrToStr()))
+                    self.pdebug(
+                        DIGN, ("Ignoring %s packet from process %s " + "in the process blacklist.") % (pkt.proto, comm)
+                    )
+                    self.pdebug(DIGN, "  %s" % (pkt.hdrToStr()))
                     return True
 
                 # Check process whitelist
-                elif (len(self.whitelist_processes) and (comm not in
-                      self.whitelist_processes)):
-                    self.pdebug(DIGN, ('Ignoring %s packet from process %s ' +
-                                'not in the process whitelist.') % (pkt.proto,
-                                comm))
-                    self.pdebug(DIGN, '  %s' %
-                                (pkt.hdrToStr()))
+                elif len(self.whitelist_processes) and (comm not in self.whitelist_processes):
+                    self.pdebug(
+                        DIGN,
+                        ("Ignoring %s packet from process %s " + "not in the process whitelist.") % (pkt.proto, comm),
+                    )
+                    self.pdebug(DIGN, "  %s" % (pkt.hdrToStr()))
                     return True
 
                 # Check per-listener blacklisted process list
-                elif self.listener_ports.isProcessBlackListHit(
-                        pkt.proto, dport, comm):
-                    self.pdebug(DIGN, ('Ignoring %s request packet from ' +
-                                'process %s in the listener process ' +
-                                'blacklist.') % (pkt.proto, comm))
-                    self.pdebug(DIGN, '  %s' %
-                                (pkt.hdrToStr()))
+                elif self.listener_ports.isProcessBlackListHit(pkt.proto, dport, comm):
+                    self.pdebug(
+                        DIGN,
+                        ("Ignoring %s request packet from " + "process %s in the listener process " + "blacklist.")
+                        % (pkt.proto, comm),
+                    )
+                    self.pdebug(DIGN, "  %s" % (pkt.hdrToStr()))
                     return True
 
                 # Check per-listener whitelisted process list
-                elif self.listener_ports.isProcessWhiteListMiss(
-                        pkt.proto, dport, comm):
-                    self.pdebug(DIGN, ('Ignoring %s request packet from ' +
-                                'process %s not in the listener process ' +
-                                'whitelist.') % (pkt.proto, comm))
-                    self.pdebug(DIGN, '  %s' %
-                                (pkt.hdrToStr()))
+                elif self.listener_ports.isProcessWhiteListMiss(pkt.proto, dport, comm):
+                    self.pdebug(
+                        DIGN,
+                        ("Ignoring %s request packet from " + "process %s not in the listener process " + "whitelist.")
+                        % (pkt.proto, comm),
+                    )
+                    self.pdebug(DIGN, "  %s" % (pkt.hdrToStr()))
                     return True
 
         # MultiHost mode checks
@@ -1426,33 +1394,33 @@ class DiverterBase(fnconfig.Config):
         # Forwarding blacklisted port
         if pkt.proto:
             if set(self.blacklist_ports[pkt.proto]).intersection([sport, dport]):
-                self.pdebug(DIGN, 'Forwarding blacklisted port %s packet:' %
-                            (pkt.proto))
-                self.pdebug(DIGN, '  %s' % (pkt.hdrToStr()))
+                self.pdebug(DIGN, "Forwarding blacklisted port %s packet:" % (pkt.proto))
+                self.pdebug(DIGN, "  %s" % (pkt.hdrToStr()))
                 return True
 
         # Check host blacklist
-        global_host_blacklist = self.getconfigval('hostblacklist')
+        global_host_blacklist = self.getconfigval("hostblacklist")
         if global_host_blacklist and dst_ip in global_host_blacklist:
-            self.pdebug(DIGN, ('Ignoring %s packet to %s in the host ' +
-                        'blacklist.') % (str(pkt.proto), dst_ip))
-            self.pdebug(DIGN, '  %s' % (pkt.hdrToStr()))
-            self.logger.error('IGN: host blacklist match')
+            self.pdebug(DIGN, ("Ignoring %s packet to %s in the host " + "blacklist.") % (str(pkt.proto), dst_ip))
+            self.pdebug(DIGN, "  %s" % (pkt.hdrToStr()))
+            self.logger.error("IGN: host blacklist match")
             return True
 
         # Check the port host whitelist
         if self.listener_ports.isHostWhiteListMiss(pkt.proto, dport, dst_ip):
-            self.pdebug(DIGN, ('Ignoring %s request packet to %s not in ' +
-                        'the listener host whitelist.') % (pkt.proto,
-                        dst_ip))
-            self.pdebug(DIGN, '  %s' % (pkt.hdrToStr()))
+            self.pdebug(
+                DIGN,
+                ("Ignoring %s request packet to %s not in " + "the listener host whitelist.") % (pkt.proto, dst_ip),
+            )
+            self.pdebug(DIGN, "  %s" % (pkt.hdrToStr()))
             return True
 
         # Check the port host blacklist
         if self.listener_ports.isHostBlackListHit(pkt.proto, dport, dst_ip):
-            self.pdebug(DIGN, ('Ignoring %s request packet to %s in the ' +
-                        'listener host blacklist.') % (pkt.proto, dst_ip))
-            self.pdebug(DIGN, '  %s' % (pkt.hdrToStr()))
+            self.pdebug(
+                DIGN, ("Ignoring %s request packet to %s in the " + "listener host blacklist.") % (pkt.proto, dst_ip)
+            )
+            self.pdebug(DIGN, "  %s" % (pkt.hdrToStr()))
             return True
 
         # Duplicated from diverters/windows.py:
@@ -1465,17 +1433,14 @@ class DiverterBase(fnconfig.Config):
         # is actually a SYN packet
         if pid == self.pid:
             if (
-                ((dst_ip in self.ip_addrs[pkt.ipver]) and
-                (not dst_ip.startswith('127.'))) and
-                ((src_ip in self.ip_addrs[pkt.ipver]) and
-                (not dst_ip.startswith('127.'))) and
-                (not self.listener_ports.intersectsWithPorts(pkt.proto, [sport, dport]))
-                ):
+                ((dst_ip in self.ip_addrs[pkt.ipver]) and (not dst_ip.startswith("127.")))
+                and ((src_ip in self.ip_addrs[pkt.ipver]) and (not dst_ip.startswith("127.")))
+                and (not self.listener_ports.intersectsWithPorts(pkt.proto, [sport, dport]))
+            ):
 
-                self.pdebug(DIGN | DFTP, 'Listener initiated %s connection' %
-                            (pkt.proto))
-                self.pdebug(DIGN | DFTP, '  %s' % (pkt.hdrToStr()))
-                self.pdebug(DIGN | DFTP, '  Blacklisting port %d' % (sport))
+                self.pdebug(DIGN | DFTP, "Listener initiated %s connection" % (pkt.proto))
+                self.pdebug(DIGN | DFTP, "  %s" % (pkt.hdrToStr()))
+                self.pdebug(DIGN | DFTP, "  Blacklisting port %d" % (sport))
                 self.blacklist_ports[pkt.proto].append(sport)
 
                 return True
@@ -1492,10 +1457,8 @@ class DiverterBase(fnconfig.Config):
         Returns:
             None
         """
-        if (pkt.is_icmp and (not self.running_on_windows or
-                pkt.icmp_id not in self.blacklist_ids["ICMP"])):
-            self.logger.info('ICMP type %d code %d %s' % (
-                pkt.icmp_type, pkt.icmp_code, pkt.hdrToStr()))
+        if pkt.is_icmp and (not self.running_on_windows or pkt.icmp_id not in self.blacklist_ids["ICMP"]):
+            self.logger.info("ICMP type %d code %d %s" % (pkt.icmp_type, pkt.icmp_code, pkt.hdrToStr()))
 
     def getOriginalDestPort(self, orig_src_ip, orig_src_port, proto):
         """Return original destination port, or None if it was not redirected.
@@ -1513,8 +1476,7 @@ class DiverterBase(fnconfig.Config):
             None, otherwise
         """
 
-        orig_src_key = fnpacket.PacketCtx.gen_endpoint_key(proto, orig_src_ip,
-                                                           orig_src_port)
+        orig_src_key = fnpacket.PacketCtx.gen_endpoint_key(proto, orig_src_ip, orig_src_port)
         with self.port_fwd_table_lock:
             return self.port_fwd_table.get(orig_src_key)
 
@@ -1540,18 +1502,17 @@ class DiverterBase(fnconfig.Config):
         if self.check_should_ignore(pkt, pid, comm):
             return
 
-        self.pdebug(DIPNAT, 'Condition 1 test')
+        self.pdebug(DIPNAT, "Condition 1 test")
         # Condition 1: If the remote IP address is foreign to this system,
         # then redirect it to a local IP address.
         if self.single_host_mode and (pkt.dst_ip not in self.ip_addrs[pkt.ipver]):
-            self.pdebug(DIPNAT, 'Condition 1 satisfied')
+            self.pdebug(DIPNAT, "Condition 1 satisfied")
             with self.ip_fwd_table_lock:
                 self.ip_fwd_table[pkt.skey] = pkt.dst_ip
 
             newdst = self.getNewDestinationIp(pkt.src_ip)
 
-            self.pdebug(DIPNAT, 'REDIRECTING %s to IP %s' %
-                        (pkt.hdrToStr(), newdst))
+            self.pdebug(DIPNAT, "REDIRECTING %s to IP %s" % (pkt.hdrToStr(), newdst))
             pkt.dst_ip = newdst
 
         else:
@@ -1566,8 +1527,7 @@ class DiverterBase(fnconfig.Config):
 
             with self.ip_fwd_table_lock:
                 if pkt.skey in self.ip_fwd_table:
-                    self.pdebug(DIPNAT, ' - DELETING ipfwd key entry: %s' %
-                                (pkt.skey))
+                    self.pdebug(DIPNAT, " - DELETING ipfwd key entry: %s" % (pkt.skey))
                     del self.ip_fwd_table[pkt.skey]
 
     def maybe_fixup_srcip(self, crit, pkt, pid, comm):
@@ -1598,14 +1558,13 @@ class DiverterBase(fnconfig.Config):
         self.pdebug(DIPNAT, "Condition 4 test: was remote endpoint IP fwd'd?")
         with self.ip_fwd_table_lock:
             if self.single_host_mode and (pkt.dkey in self.ip_fwd_table):
-                self.pdebug(DIPNAT, 'Condition 4 satisfied')
-                self.pdebug(DIPNAT, ' = FOUND ipfwd key entry: ' + pkt.dkey)
+                self.pdebug(DIPNAT, "Condition 4 satisfied")
+                self.pdebug(DIPNAT, " = FOUND ipfwd key entry: " + pkt.dkey)
                 new_srcip = self.ip_fwd_table[pkt.dkey]
-                self.pdebug(DIPNAT, 'MASQUERADING %s from IP %s' %
-                            (pkt.hdrToStr(), new_srcip))
+                self.pdebug(DIPNAT, "MASQUERADING %s from IP %s" % (pkt.hdrToStr(), new_srcip))
                 pkt.src_ip = new_srcip
             else:
-                self.pdebug(DIPNAT, ' ! NO SUCH ipfwd key entry: ' + pkt.dkey)
+                self.pdebug(DIPNAT, " ! NO SUCH ipfwd key entry: " + pkt.dkey)
 
     def maybe_redir_port(self, crit, pkt, pid, comm):
         """Conditionally send packets to the default listener for this proto.
@@ -1645,8 +1604,7 @@ class DiverterBase(fnconfig.Config):
 
         bound_ports = self.listener_ports.getPortList(pkt.proto)
         if dport_hidden_listener or self.decide_redir_port(pkt, bound_ports):
-            self.pdebug(DDPFV, 'Condition 2 satisfied: Packet destined for '
-                        'unbound port or hidden listener')
+            self.pdebug(DDPFV, "Condition 2 satisfied: Packet destined for " "unbound port or hidden listener")
 
             # Post-condition 1: General ignore conditions are not met, or this
             # is part of a conversation that is already being ignored.
@@ -1664,8 +1622,7 @@ class DiverterBase(fnconfig.Config):
 
             # Is this conversation already being ignored for DPF purposes?
             with self.ignore_table_lock:
-                if ((pkt.dkey in self.ignore_table) and
-                        (self.ignore_table[pkt.dkey] == pkt.sport)):
+                if (pkt.dkey in self.ignore_table) and (self.ignore_table[pkt.dkey] == pkt.sport):
                     # This is a reply (e.g. a TCP RST) from the
                     # non-port-forwarded server that the non-port-forwarded
                     # client was trying to talk to. Leave it alone.
@@ -1678,12 +1635,11 @@ class DiverterBase(fnconfig.Config):
 
             # Record the foreign endpoint and old destination port in the port
             # forwarding table
-            self.pdebug(DDPFV, ' + ADDING portfwd key entry: ' + pkt.skey)
+            self.pdebug(DDPFV, " + ADDING portfwd key entry: " + pkt.skey)
             with self.port_fwd_table_lock:
                 self.port_fwd_table[pkt.skey] = pkt.dport
 
-            self.pdebug(DDPF, 'Redirecting %s to go to port %d' %
-                        (pkt.hdrToStr(), default))
+            self.pdebug(DDPF, "Redirecting %s to go to port %d" % (pkt.hdrToStr(), default))
             pkt.dport = default
 
         else:
@@ -1735,21 +1691,19 @@ class DiverterBase(fnconfig.Config):
             new_sport = self.port_fwd_table.get(pkt.dkey)
 
         if new_sport:
-            self.pdebug(DDPFV, 'Condition 3 satisfied: must fix up ' +
-                        'source port')
-            self.pdebug(DDPFV, ' = FOUND portfwd key entry: ' + pkt.dkey)
-            self.pdebug(DDPF, 'MASQUERADING %s to come from port %d' %
-                              (pkt.hdrToStr(), new_sport))
+            self.pdebug(DDPFV, "Condition 3 satisfied: must fix up " + "source port")
+            self.pdebug(DDPFV, " = FOUND portfwd key entry: " + pkt.dkey)
+            self.pdebug(DDPF, "MASQUERADING %s to come from port %d" % (pkt.hdrToStr(), new_sport))
             pkt.sport = new_sport
         else:
-            self.pdebug(DDPFV, ' ! NO SUCH portfwd key entry: ' + pkt.dkey)
+            self.pdebug(DDPFV, " ! NO SUCH portfwd key entry: " + pkt.dkey)
 
         return pkt.hdr if pkt.mangled else None
 
     def delete_stale_port_fwd_key(self, skey):
         with self.port_fwd_table_lock:
             if skey in self.port_fwd_table:
-                self.pdebug(DDPFV, ' - DELETING portfwd key entry: ' + skey)
+                self.pdebug(DDPFV, " - DELETING portfwd key entry: " + skey)
                 del self.port_fwd_table[skey]
 
     def decide_redir_port(self, pkt, bound_ports):
@@ -1767,28 +1721,24 @@ class DiverterBase(fnconfig.Config):
             False otherwise
         """
         # A, B, C, D for easy manipulation; full names for readability only.
-        a = src_local = (pkt.src_ip in self.ip_addrs[pkt.ipver])
+        a = src_local = pkt.src_ip in self.ip_addrs[pkt.ipver]
         c = sport_bound = pkt.sport in (bound_ports)
         d = dport_bound = pkt.dport in (bound_ports)
 
         if self.pdebug_level & DDPFV:
             # Unused logic term not calculated except for debug output
-            b = dst_local = (pkt.dst_ip in self.ip_addrs[pkt.ipver])
+            b = dst_local = pkt.dst_ip in self.ip_addrs[pkt.ipver]
 
-            self.pdebug(DDPFV, 'src %s (%s)' %
-                        (str(pkt.src_ip), ['foreign', 'local'][a]))
-            self.pdebug(DDPFV, 'dst %s (%s)' %
-                        (str(pkt.dst_ip), ['foreign', 'local'][b]))
-            self.pdebug(DDPFV, 'sport %s (%sbound)' %
-                        (str(pkt.sport), ['un', ''][c]))
-            self.pdebug(DDPFV, 'dport %s (%sbound)' %
-                        (str(pkt.dport), ['un', ''][d]))
+            self.pdebug(DDPFV, "src %s (%s)" % (str(pkt.src_ip), ["foreign", "local"][a]))
+            self.pdebug(DDPFV, "dst %s (%s)" % (str(pkt.dst_ip), ["foreign", "local"][b]))
+            self.pdebug(DDPFV, "sport %s (%sbound)" % (str(pkt.sport), ["un", ""][c]))
+            self.pdebug(DDPFV, "dport %s (%sbound)" % (str(pkt.dport), ["un", ""][d]))
 
             # Convenience function: binary representation of a bool
             def bn(x):
-                return '1' if x else '0'  # Bool -> binary
+                return "1" if x else "0"  # Bool -> binary
 
-            self.pdebug(DDPFV, 'abcd = ' + bn(a) + bn(b) + bn(c) + bn(d))
+            self.pdebug(DDPFV, "abcd = " + bn(a) + bn(b) + bn(c) + bn(d))
 
         return (not a and not d) or (not c and not d)
 
@@ -1801,11 +1751,9 @@ class DiverterBase(fnconfig.Config):
         Returns:
             None
         """
-        session = namedtuple('session', ['dst_ip', 'dport', 'pid',
-                                         'comm', 'dport0', 'proto'])
+        session = namedtuple("session", ["dst_ip", "dport", "pid", "comm", "dport0", "proto"])
         pid, comm = self.get_pid_comm(pkt)
-        self.sessions[pkt.sport] = session(pkt.dst_ip, pkt.dport, pid,
-                                           comm, pkt._dport0, pkt.proto)
+        self.sessions[pkt.sport] = session(pkt.dst_ip, pkt.dport, pid, comm, pkt._dport0, pkt.proto)
 
     def maybeExecuteCmd(self, pkt, pid, comm):
         """Execute any ExecuteCmd associated with this port/listener.
@@ -1823,11 +1771,10 @@ class DiverterBase(fnconfig.Config):
 
         execCmd = self.build_cmd(pkt, pid, comm)
         if execCmd:
-            self.logger.info('Executing command: %s' % (execCmd))
+            self.logger.info("Executing command: %s" % (execCmd))
             self.execute_detached(execCmd)
 
-    def mapProxySportToOrigSport(self, proto, orig_sport, proxy_sport,
-            is_ssl_encrypted):
+    def mapProxySportToOrigSport(self, proto, orig_sport, proxy_sport, is_ssl_encrypted):
         """Maps Proxy initiated source ports to their original source ports.
 
         The Proxy listener uses this method to notify the diverter about the
@@ -1846,8 +1793,7 @@ class DiverterBase(fnconfig.Config):
         self.proxy_sport_to_orig_sport_map[(proto, proxy_sport)] = orig_sport
         self.is_proxied_pkt_ssl_encrypted[(proto, proxy_sport)] = is_ssl_encrypted
 
-    def logNbi(self, sport, nbi, proto, application_layer_proto,
-            is_ssl_encrypted):
+    def logNbi(self, sport, nbi, proto, application_layer_proto, is_ssl_encrypted):
         """Collects the NBIs from all listeners into a dictionary.
 
         All listeners use this method to notify the diverter about any NBI
@@ -1864,7 +1810,7 @@ class DiverterBase(fnconfig.Config):
             None
         """
         proxied_nbi = (proto, sport) in self.proxy_sport_to_orig_sport_map
-        
+
         # For proxied nbis, override the listener's is_ssl_encrypted with Proxy
         # listener's is_ssl_encrypted, and update the original sport. For
         # non-proxied nbis, use listener provided is_ssl_encrypted and sport.
@@ -1879,31 +1825,30 @@ class DiverterBase(fnconfig.Config):
 
         dst_ip, _, pid, comm, orig_dport, transport_layer_proto = self.sessions.get(orig_sport)
 
-        if application_layer_proto == '':
+        if application_layer_proto == "":
             application_layer_proto = transport_layer_proto
 
         # Normalize pid and comm for MultiHost mode
-        if pid is None and comm is None and self.network_mode.lower() == 'multihost':
+        if pid is None and comm is None and self.network_mode.lower() == "multihost":
             self.remote_pid_counter += 1
             pid = self.remote_pid_counter
-            comm = 'Remote Process'
+            comm = "Remote Process"
 
         # Craft the dictionary
         nbi_entry = {
-            'transport_layer_proto': transport_layer_proto,
-            'sport': orig_sport,
-            'dst_ip': dst_ip,
-            'dport': orig_dport,
-            'is_ssl_encrypted': is_ssl_encrypted,
-            'network_mode': self.network_mode.lower(),
-            'nbi': nbi
-            }
+            "transport_layer_proto": transport_layer_proto,
+            "sport": orig_sport,
+            "dst_ip": dst_ip,
+            "dport": orig_dport,
+            "is_ssl_encrypted": is_ssl_encrypted,
+            "network_mode": self.network_mode.lower(),
+            "nbi": nbi,
+        }
         application_layer_proto = application_layer_proto.lower()
- 
+
         # If it's a new NBI from an exisitng process or existing protocol,
         # append the nbi, else create new key
-        self.nbis.setdefault((pid, comm), {}).setdefault(application_layer_proto,
-                                                         []).append(nbi_entry)
+        self.nbis.setdefault((pid, comm), {}).setdefault(application_layer_proto, []).append(nbi_entry)
 
     def prettyPrintNbi(self):
         """Convenience method to print all NBIs in appropriate format upon
@@ -1939,34 +1884,31 @@ class DiverterBase(fnconfig.Config):
         process_counter = 0
         for process_info, values in self.nbis.items():
             process_counter += 1
-            self.logger.info(f"[{process_counter}] Process ID: "
-                    f"{process_info[0]}, Process Name: {process_info[1]}")
+            self.logger.info(f"[{process_counter}] Process ID: " f"{process_info[0]}, Process Name: {process_info[1]}")
 
             for application_layer_proto, nbi_entry in values.items():
-                self.logger.info(f"{indent*2} Protocol: "
-                                 f"{application_layer_proto}")
+                self.logger.info(f"{indent*2} Protocol: " f"{application_layer_proto}")
                 nbi_counter = 0
 
                 for attributes in nbi_entry:
                     nbi_counter += 1
-                    self.logger.info(f"{indent*3}{nbi_counter}.Transport Layer "
-                                     f"Protocol: {attributes['transport_layer_proto']}")
+                    self.logger.info(
+                        f"{indent*3}{nbi_counter}.Transport Layer " f"Protocol: {attributes['transport_layer_proto']}"
+                    )
                     self.logger.info(f"{indent*4}Source port: {attributes['sport']}")
                     self.logger.info(f"{indent*4}Destination IP: {attributes['dst_ip']}")
                     self.logger.info(f"{indent*4}Destination port: {attributes['dport']}")
-                    self.logger.info(f"{indent*4}SSL encrypted: "
-                                     f"{attributes['is_ssl_encrypted']}")
-                    self.logger.info(f"{indent*4}Network mode: "
-                                     f"{attributes['network_mode']}")
+                    self.logger.info(f"{indent*4}SSL encrypted: " f"{attributes['is_ssl_encrypted']}")
+                    self.logger.info(f"{indent*4}Network mode: " f"{attributes['network_mode']}")
 
-                    for key, v in attributes['nbi'].items():
+                    for key, v in attributes["nbi"].items():
                         if v is not None:
                             # Let's convert the NBI value to str if it's not already
                             if isinstance(v, bytes):
-                                v = v.decode('utf-8')
+                                v = v.decode("utf-8")
 
                             # Let's print maximum 40 characters for NBI values
-                            v = (v[:40]+"...") if len(v)>40 else v
+                            v = (v[:40] + "...") if len(v) > 40 else v
                         self.logger.info(f"{indent*6}-{key}: {v}")
 
                     self.logger.info("\r")
@@ -1978,7 +1920,7 @@ class DiverterBase(fnconfig.Config):
         to the main working directory of flare-fakenet-ng. Called by stop() method
         of diverter.
         """
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
             # Inside a Pyinstaller bundle
             fakenet_dir_path = os.path.dirname(sys.executable)
         else:
@@ -1988,13 +1930,13 @@ class DiverterBase(fnconfig.Config):
         template_loader = jinja2.FileSystemLoader(searchpath=os.path.dirname(template_file))
         template_env = jinja2.Environment(loader=template_loader)
         template = template_env.get_template(os.path.basename(template_file))
-        
-        timestamp = time.strftime('%Y%m%d_%H%M%S')
+
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
         output_filename = f"report_{timestamp}.html"
 
         with open(output_filename, "w") as output_file:
             output_file.write(template.render(nbis=self.nbis))
-        
+
         self.logger.info(f"Generated new HTML report: {output_filename}")
 
     def isProcessBlackListed(self, proto, sport=None, process_name=None, dport=None):
@@ -2021,26 +1963,28 @@ class DiverterBase(fnconfig.Config):
 
             # Check process blacklist
             if process_name in self.blacklist_processes:
-                self.pdebug(DIGN, ('Ignoring %s packet from process %s ' +
-                            'in the process blacklist.') % (proto,
-                            process_name))
+                self.pdebug(
+                    DIGN, ("Ignoring %s packet from process %s " + "in the process blacklist.") % (proto, process_name)
+                )
                 return True, process_name, pid
 
             # Check per-listener blacklisted process list
-            if self.listener_ports.isProcessBlackListHit(
-                    proto, dport, process_name):
-                self.pdebug(DIGN, ('Ignoring %s request packet from ' +
-                            'process %s in the listener process ' +
-                            'blacklist.') % (proto, process_name))
+            if self.listener_ports.isProcessBlackListHit(proto, dport, process_name):
+                self.pdebug(
+                    DIGN,
+                    ("Ignoring %s request packet from " + "process %s in the listener process " + "blacklist.")
+                    % (proto, process_name),
+                )
                 return True, process_name, pid
         return False, process_name, pid
-    
-    
-class DiverterListenerCallbacks():
+
+
+class DiverterListenerCallbacks:
     """A wrapper class for the diverter that provides controlled access to
     specific methods required by listeners for reporting NBIs.  This prevents
     exposing the entire diverter to the listeners.
     """
+
     def __init__(self, diverter):
         """Initialize the DiverterWrapper.
 
@@ -2049,18 +1993,15 @@ class DiverterListenerCallbacks():
         """
         self.__diverter = diverter
 
-    def logNbi(self, sport, nbi, proto, application_layer_proto,
-            is_ssl_encrypted):
+    def logNbi(self, sport, nbi, proto, application_layer_proto, is_ssl_encrypted):
         """Delegate the logging of NBIs to the diverter.
 
         This method forwards the provided NBI information to the logNbi() method
         in the underlying diverter object. Called by all listeners to log NBIs.
         """
-        self.__diverter.logNbi(sport, nbi, proto, application_layer_proto,
-                               is_ssl_encrypted)
+        self.__diverter.logNbi(sport, nbi, proto, application_layer_proto, is_ssl_encrypted)
 
-    def mapProxySportToOrigSport(self, proto, orig_sport, proxy_sport,
-            is_ssl_encrypted):
+    def mapProxySportToOrigSport(self, proto, orig_sport, proxy_sport, is_ssl_encrypted):
         """Delegate the mapping of proxy sport to original sport to the
         diverter.
 
@@ -2069,10 +2010,8 @@ class DiverterListenerCallbacks():
         Called by ProxyListener to report the mapping between proxy initiated
         source port and original source port.
         """
-        self.__diverter.mapProxySportToOrigSport(proto, orig_sport, proxy_sport,
-                                                 is_ssl_encrypted)
+        self.__diverter.mapProxySportToOrigSport(proto, orig_sport, proxy_sport, is_ssl_encrypted)
 
     def isProcessBlackListed(self, proto, sport):
-        """Check if the process is blacklisted.
-        """
+        """Check if the process is blacklisted."""
         return self.__diverter.isProcessBlackListed(proto, sport=sport)

--- a/fakenet/diverters/fnconfig.py
+++ b/fakenet/diverters/fnconfig.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Google LLC
 
+
 class Config(object):
     """Configuration primitives.
 
@@ -32,13 +33,13 @@ class Config(object):
         for entry in stringlists:
             stringlist = self.getconfigval(entry)
             if stringlist:
-                expanded = [s.strip() for s in stringlist.split(',')]
+                expanded = [s.strip() for s in stringlist.split(",")]
                 self.setconfigval(entry, expanded)
 
         for entry in idlists:
             idlist = self.getconfigval(entry)
             if idlist:
-                expanded = [int(c) for c in idlist.split(',')]
+                expanded = [int(c) for c in idlist.split(",")]
                 self.setconfigval(entry, expanded)
 
     def reconfigure(self, portlists=[], stringlists=[]):
@@ -55,19 +56,19 @@ class Config(object):
 
     def _expand_ports(self, ports_list):
         ports = []
-        for i in ports_list.split(','):
-            if '-' not in i:
+        for i in ports_list.split(","):
+            if "-" not in i:
                 ports.append(int(i))
             else:
-                l, h = list(map(int, i.split('-')))
+                l, h = list(map(int, i.split("-")))
                 ports += list(range(l, h + 1))
         return ports
 
     def _fuzzy_true(self, value):
-        return value.lower() in ['yes', 'on', 'true', 'enable', 'enabled']
+        return value.lower() in ["yes", "on", "true", "enable", "enabled"]
 
     def _fuzzy_false(self, value):
-        return value.lower() in ['no', 'off', 'false', 'disable', 'disabled']
+        return value.lower() in ["no", "off", "false", "disable", "disabled"]
 
     def is_configured(self, opt):
         return opt.lower() in list(self._dict.keys())
@@ -76,12 +77,10 @@ class Config(object):
         return not self.is_configured(opt)
 
     def is_set(self, opt):
-        return (self.is_configured(opt) and
-                self._fuzzy_true(self._dict[opt.lower()]))
+        return self.is_configured(opt) and self._fuzzy_true(self._dict[opt.lower()])
 
     def is_clear(self, opt):
-        return (self.is_configured(opt) and
-                self._fuzzy_false(self._dict[opt.lower()]))
+        return self.is_configured(opt) and self._fuzzy_false(self._dict[opt.lower()])
 
     def getconfigval(self, opt, default=None):
         return self._dict[opt.lower()] if self.is_configured(opt) else default

--- a/fakenet/diverters/winutil.py
+++ b/fakenet/diverters/winutil.py
@@ -2,8 +2,8 @@
 
 #!/usr/bin/env python
 import logging
-logging.basicConfig(format='%(asctime)s [%(name)18s] %(message)s',
-                    datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
+
+logging.basicConfig(format="%(asctime)s [%(name)18s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG)
 
 import ctypes
 from ctypes import *
@@ -54,7 +54,7 @@ SERVICE_CONTROL_STOP = 0x1
 SERVICE_CONTROL_PAUSE = 0x2
 SERVICE_CONTROL_CONTINUE = 0x3
 
-SERVICE_NO_CHANGE = 0xffffffff
+SERVICE_NO_CHANGE = 0xFFFFFFFF
 
 SERVICE_AUTO_START = 0x2
 SERVICE_BOOT_START = 0x0
@@ -65,16 +65,17 @@ SERVICE_SYSTEM_START = 0x1
 
 class SERVICE_STATUS_PROCESS(Structure):
     _fields_ = [
-        ("dwServiceType",             DWORD),
-        ("dwCurrentState",            DWORD),
-        ("dwControlsAccepted",        DWORD),
-        ("dwWin32ExitCode",           DWORD),
+        ("dwServiceType", DWORD),
+        ("dwCurrentState", DWORD),
+        ("dwControlsAccepted", DWORD),
+        ("dwWin32ExitCode", DWORD),
         ("dwServiceSpecificExitCode", DWORD),
-        ("dwCheckPoint",              DWORD),
-        ("dwWaitHint",                DWORD),
-        ("dwProcessId",               DWORD),
-        ("dwServiceFlags",            DWORD),
+        ("dwCheckPoint", DWORD),
+        ("dwWaitHint", DWORD),
+        ("dwProcessId", DWORD),
+        ("dwServiceFlags", DWORD),
     ]
+
 
 ##############################################################################
 # Process related functions
@@ -89,20 +90,18 @@ TCP_TABLE_OWNER_PID_ALL = 5
 
 class MIB_TCPROW_OWNER_PID(Structure):
     _fields_ = [
-        ("dwState",      DWORD),
-        ("dwLocalAddr",  DWORD),
-        ("dwLocalPort",  DWORD),
+        ("dwState", DWORD),
+        ("dwLocalAddr", DWORD),
+        ("dwLocalPort", DWORD),
         ("dwRemoteAddr", DWORD),
         ("dwRemotePort", DWORD),
-        ("dwOwningPid",  DWORD)
+        ("dwOwningPid", DWORD),
     ]
 
 
 class MIB_TCPTABLE_OWNER_PID(Structure):
-    _fields_ = [
-        ("dwNumEntries", DWORD),
-        ("table",        MIB_TCPROW_OWNER_PID * 512)
-    ]
+    _fields_ = [("dwNumEntries", DWORD), ("table", MIB_TCPROW_OWNER_PID * 512)]
+
 
 ##############################################################################
 # GetExtendedUdpTable constants and structures
@@ -112,18 +111,12 @@ UDP_TABLE_OWNER_PID = 1
 
 
 class MIB_UDPROW_OWNER_PID(Structure):
-    _fields_ = [
-        ("dwLocalAddr", DWORD),
-        ("dwLocalPort", DWORD),
-        ("dwOwningPid", DWORD)
-    ]
+    _fields_ = [("dwLocalAddr", DWORD), ("dwLocalPort", DWORD), ("dwOwningPid", DWORD)]
 
 
 class MIB_UDPTABLE_OWNER_PID(Structure):
-    _fields_ = [
-        ("dwNumEntries", DWORD),
-        ("table",        MIB_UDPROW_OWNER_PID * 512)
-    ]
+    _fields_ = [("dwNumEntries", DWORD), ("table", MIB_UDPROW_OWNER_PID * 512)]
+
 
 ###############################################################################
 # GetProcessImageFileName constants and structures
@@ -152,15 +145,15 @@ IFOPERSTATUSUP = 1
 
 class SOCKADDR(Structure):
     _fields_ = [
-        ("sa_family",           c_ushort),
-        ("sa_data",             c_char * 14),
+        ("sa_family", c_ushort),
+        ("sa_data", c_char * 14),
     ]
 
 
 class SOCKET_ADDRESS(Structure):
     _fields_ = [
-        ("Sockaddr",            POINTER(SOCKADDR)),
-        ("SockaddrLength",      INT),
+        ("Sockaddr", POINTER(SOCKADDR)),
+        ("SockaddrLength", INT),
     ]
 
 
@@ -169,11 +162,11 @@ class IP_ADAPTER_PREFIX(Structure):
 
 
 IP_ADAPTER_PREFIX._fields_ = [
-    ("Length",              ULONG),
-    ("Flags",               DWORD),
-    ("Next",                POINTER(IP_ADAPTER_PREFIX)),
-    ("Address",             SOCKET_ADDRESS),
-    ("PrefixLength",        ULONG),
+    ("Length", ULONG),
+    ("Flags", DWORD),
+    ("Next", POINTER(IP_ADAPTER_PREFIX)),
+    ("Address", SOCKET_ADDRESS),
+    ("PrefixLength", ULONG),
 ]
 
 
@@ -182,43 +175,43 @@ class IP_ADAPTER_ADDRESSES(Structure):
 
 
 IP_ADAPTER_ADDRESSES._fields_ = [
-    ("Length",                  ULONG),
-    ("IfIndex",                 DWORD),
-    ("Next",                    POINTER(IP_ADAPTER_ADDRESSES)),
-    ("AdapterName",             LPSTR),
-    ("FirstUnicastAddress",     c_void_p),  # Not used
-    ("FirstAnycastAddress",     c_void_p),  # Not used
-    ("FirstMulticastAddress",   c_void_p),  # Not used
-    ("FirstDnsServerAddress",   c_void_p),  # Not used
-    ("DnsSuffix",               LPWSTR),
-    ("Description",             LPWSTR),
-    ("FriendlyName",            LPWSTR),
-    ("PhysicalAddress",         BYTE * MAX_ADAPTER_ADDRESS_LENGTH),
-    ("PhysicalAddressLength",   DWORD),
-    ("Flags",                   DWORD),
-    ("Mtu",                     DWORD),
-    ("IfType",                  DWORD),
-    ("OperStatus",              DWORD),
-    ("Ipv6IfIndex",             DWORD),
-    ("ZoneIndices",             DWORD * 16),
-    ("FirstPrefix",             POINTER(IP_ADAPTER_PREFIX)),
-    ("TransmitLinkSpeed",       ULONG64),
-    ("ReceiveLinkSpeed",        ULONG64),
-    ("FirstWinsServerAddress",  c_void_p),  # Not used
-    ("FirstGatewayAddress",     c_void_p),  # Not used
-    ("Ipv4Metric",              ULONG),
-    ("Ipv6Metric",              ULONG),
-    ("Luid",                    ULONG64),
-    ("Dhcpv4Server",            SOCKET_ADDRESS),
-    ("CompartmentId",           DWORD),
-    ("NetworkGuid",             BYTE * 16),
-    ("ConnectionType",          DWORD),
-    ("TunnelType",              DWORD),
-    ("Dhcpv6Server",            SOCKET_ADDRESS),
-    ("Dhcpv6ClientDuid",        BYTE * MAX_DHCPV6_DUID_LENGTH),
-    ("Dhcpv6ClientDuidLength",  ULONG),
-    ("Dhcpv6Iaid",              ULONG),
-    ("FirstDnsSuffix",          c_void_p),  # Not used
+    ("Length", ULONG),
+    ("IfIndex", DWORD),
+    ("Next", POINTER(IP_ADAPTER_ADDRESSES)),
+    ("AdapterName", LPSTR),
+    ("FirstUnicastAddress", c_void_p),  # Not used
+    ("FirstAnycastAddress", c_void_p),  # Not used
+    ("FirstMulticastAddress", c_void_p),  # Not used
+    ("FirstDnsServerAddress", c_void_p),  # Not used
+    ("DnsSuffix", LPWSTR),
+    ("Description", LPWSTR),
+    ("FriendlyName", LPWSTR),
+    ("PhysicalAddress", BYTE * MAX_ADAPTER_ADDRESS_LENGTH),
+    ("PhysicalAddressLength", DWORD),
+    ("Flags", DWORD),
+    ("Mtu", DWORD),
+    ("IfType", DWORD),
+    ("OperStatus", DWORD),
+    ("Ipv6IfIndex", DWORD),
+    ("ZoneIndices", DWORD * 16),
+    ("FirstPrefix", POINTER(IP_ADAPTER_PREFIX)),
+    ("TransmitLinkSpeed", ULONG64),
+    ("ReceiveLinkSpeed", ULONG64),
+    ("FirstWinsServerAddress", c_void_p),  # Not used
+    ("FirstGatewayAddress", c_void_p),  # Not used
+    ("Ipv4Metric", ULONG),
+    ("Ipv6Metric", ULONG),
+    ("Luid", ULONG64),
+    ("Dhcpv4Server", SOCKET_ADDRESS),
+    ("CompartmentId", DWORD),
+    ("NetworkGuid", BYTE * 16),
+    ("ConnectionType", DWORD),
+    ("TunnelType", DWORD),
+    ("Dhcpv6Server", SOCKET_ADDRESS),
+    ("Dhcpv6ClientDuid", BYTE * MAX_DHCPV6_DUID_LENGTH),
+    ("Dhcpv6ClientDuidLength", ULONG),
+    ("Dhcpv6Iaid", ULONG),
+    ("FirstDnsSuffix", c_void_p),  # Not used
 ]
 
 ###############################################################################
@@ -235,13 +228,13 @@ IF_TYPE_IEEE80211 = 71
 
 class IP_ADDRESS_STRING(Structure):
     _fields_ = [
-        ("String",               c_char * 16),
+        ("String", c_char * 16),
     ]
 
 
 class IP_MASK_STRING(Structure):
     _fields_ = [
-        ("String",               c_char * 16),
+        ("String", c_char * 16),
     ]
 
 
@@ -250,10 +243,10 @@ class IP_ADDR_STRING(Structure):
 
 
 IP_ADDR_STRING._fields_ = [
-    ("Next",                POINTER(IP_ADDR_STRING)),
-    ("IpAddress",           IP_ADDRESS_STRING),
-    ("IpMask",              IP_MASK_STRING),
-    ("Context",             DWORD),
+    ("Next", POINTER(IP_ADDR_STRING)),
+    ("IpAddress", IP_ADDRESS_STRING),
+    ("IpMask", IP_MASK_STRING),
+    ("Context", DWORD),
 ]
 
 
@@ -262,25 +255,24 @@ class IP_ADAPTER_INFO(Structure):
 
 
 IP_ADAPTER_INFO._fields_ = [
-    ("Next",                POINTER(IP_ADAPTER_INFO)),
-    ("ComboIndex",          DWORD),
-    ("AdapterName",         c_char * (MAX_ADAPTER_NAME_LENGTH + 4)),
-    ("Description",         c_char * (MAX_ADAPTER_DESCRIPTION_LENGTH + 4)),
-    ("AddressLength",       UINT),
-    ("Address",             BYTE * MAX_ADAPTER_LENGTH),
-    ("Index",               DWORD),
-    ("Type",                UINT),
-    ("DhcpEnabled",         UINT),
-    ("CurrentIpAddress",    c_void_p),  # Not used
-    ("IpAddressList",       IP_ADDR_STRING),
-    ("GatewayList",         IP_ADDR_STRING),
-    ("DhcpServer",          IP_ADDR_STRING),
-    ("HaveWins",            BOOL),
-    ("PrimaryWinsServer",   IP_ADDR_STRING),
+    ("Next", POINTER(IP_ADAPTER_INFO)),
+    ("ComboIndex", DWORD),
+    ("AdapterName", c_char * (MAX_ADAPTER_NAME_LENGTH + 4)),
+    ("Description", c_char * (MAX_ADAPTER_DESCRIPTION_LENGTH + 4)),
+    ("AddressLength", UINT),
+    ("Address", BYTE * MAX_ADAPTER_LENGTH),
+    ("Index", DWORD),
+    ("Type", UINT),
+    ("DhcpEnabled", UINT),
+    ("CurrentIpAddress", c_void_p),  # Not used
+    ("IpAddressList", IP_ADDR_STRING),
+    ("GatewayList", IP_ADDR_STRING),
+    ("DhcpServer", IP_ADDR_STRING),
+    ("HaveWins", BOOL),
+    ("PrimaryWinsServer", IP_ADDR_STRING),
     ("SecondaryWinsServer", IP_ADDR_STRING),
-    ("LeaseObtained",       c_ulong),
-    ("LeaseExpires",        c_ulong),
-
+    ("LeaseObtained", c_ulong),
+    ("LeaseExpires", c_ulong),
 ]
 
 ###############################################################################
@@ -298,13 +290,13 @@ NDIS_IF_MAX_STRING_SIZE = 256
 
 class IP_ADDRESS_STRING(Structure):
     _fields_ = [
-        ("String",               c_char * 16),
+        ("String", c_char * 16),
     ]
 
 
 class IP_MASK_STRING(Structure):
     _fields_ = [
-        ("String",               c_char * 16),
+        ("String", c_char * 16),
     ]
 
 
@@ -313,24 +305,24 @@ class IP_ADDR_STRING(Structure):
 
 
 IP_ADDR_STRING._fields_ = [
-    ("Next",                POINTER(IP_ADDR_STRING)),
-    ("IpAddress",           IP_ADDRESS_STRING),
-    ("IpMask",              IP_MASK_STRING),
-    ("Context",             DWORD),
+    ("Next", POINTER(IP_ADDR_STRING)),
+    ("IpAddress", IP_ADDRESS_STRING),
+    ("IpMask", IP_MASK_STRING),
+    ("Context", DWORD),
 ]
 
 
 class FIXED_INFO(Structure):
     _fields_ = [
-        ("HostName",            c_char * (MAX_HOSTNAME_LEN + 4)),
-        ("DomainName",          c_char * (MAX_DOMAIN_NAME_LEN + 4)),
-        ("CurrentDnsServer",    c_void_p),  # Not used
-        ("DnsServerList",       IP_ADDR_STRING),
-        ("NodeType",            UINT),
-        ("ScopeId",             c_char * (MAX_SCOPE_ID_LEN + 4)),
-        ("EnableRouting",       UINT),
-        ("EnableProxy",         UINT),
-        ("EnableDns",           UINT),
+        ("HostName", c_char * (MAX_HOSTNAME_LEN + 4)),
+        ("DomainName", c_char * (MAX_DOMAIN_NAME_LEN + 4)),
+        ("CurrentDnsServer", c_void_p),  # Not used
+        ("DnsServerList", IP_ADDR_STRING),
+        ("NodeType", UINT),
+        ("ScopeId", c_char * (MAX_SCOPE_ID_LEN + 4)),
+        ("EnableRouting", UINT),
+        ("EnableProxy", UINT),
+        ("EnableDns", UINT),
     ]
 
 
@@ -345,7 +337,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         On Linux, FTP tests will fail if you do this, so it is overridden to
         return 127.0.0.1.
         """
-        return self.loopback_ip if src_ip.startswith('127.') else self.external_ip
+        return self.loopback_ip if src_ip.startswith("127.") else self.external_ip
 
     def fix_gateway(self):
         """Check if there is a gateway configured on any of the Ethernet
@@ -364,7 +356,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
                 (ip_address, netmask) = next(self.get_ipaddresses_netmask(adapter))
                 # set the gateway ip address to be that of the virtual network adapter
                 # https://docs.vmware.com/en/VMware-Workstation-Pro/17/com.vmware.ws.using.doc/GUID-9831F49E-1A83-4881-BB8A-D4573F2C6D91.html
-                gw_address = ip_address[:ip_address.rfind('.')] + '.1'
+                gw_address = ip_address[: ip_address.rfind(".")] + ".1"
 
                 interface_name = self.get_adapter_friendlyname(adapter.Index)
 
@@ -374,20 +366,22 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
                     self.adapters_dhcp_restore.append(interface_name)
 
-                    cmd_set_gw = "netsh interface ip set address name=\"%s\" static %s %s %s" % (
-                        interface_name, ip_address, netmask, gw_address)
+                    cmd_set_gw = 'netsh interface ip set address name="%s" static %s %s %s' % (
+                        interface_name,
+                        ip_address,
+                        netmask,
+                        gw_address,
+                    )
 
                     # Configure gateway
                     try:
-                        subprocess.check_call(cmd_set_gw, shell=True,
-                                              stdout=subprocess.PIPE,
-                                              stderr=subprocess.PIPE)
+                        subprocess.check_call(cmd_set_gw, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     except subprocess.CalledProcessError as e:
-                        self.logger.error("         Failed to set gateway %s on interface %s."
-                                          % (gw_address, interface_name))
+                        self.logger.error(
+                            "         Failed to set gateway %s on interface %s." % (gw_address, interface_name)
+                        )
                     else:
-                        self.logger.info("         Setting gateway %s on interface %s"
-                                % (gw_address, interface_name))
+                        self.logger.info("         Setting gateway %s on interface %s" % (gw_address, interface_name))
                         fixed = True
 
         return fixed
@@ -414,22 +408,18 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
                     self.adapters_dns_restore.append(interface_name)
 
-                    cmd_set_dns = "netsh interface ip set dns name=\"%s\" static %s" % (
-                        interface_name, dns_address)
+                    cmd_set_dns = 'netsh interface ip set dns name="%s" static %s' % (interface_name, dns_address)
 
                     # Configure DNS server
                     try:
-                        subprocess.check_output(cmd_set_dns,
-                                              shell=True,
-                                              stderr=subprocess.PIPE)
+                        subprocess.check_output(cmd_set_dns, shell=True, stderr=subprocess.PIPE)
                     except subprocess.CalledProcessError as e:
-                        self.logger.error("         Failed to set DNS %s on interface %s."
-                                          % (dns_address, interface_name))
-                        self.logger.error("         netsh failed with error: %s"
-                                          % (e.output))
+                        self.logger.error(
+                            "         Failed to set DNS %s on interface %s." % (dns_address, interface_name)
+                        )
+                        self.logger.error("         netsh failed with error: %s" % (e.output))
                     else:
-                        self.logger.info("         Setting DNS %s on interface %s"
-                                         % (dns_address, interface_name))
+                        self.logger.info("         Setting DNS %s on interface %s" % (dns_address, interface_name))
                         fixed = True
 
         return fixed
@@ -437,9 +427,9 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
     def get_pid_comm(self, pkt):
         conn_pid, process_name = None, None
         if pkt.proto and pkt.sport:
-            if pkt.proto == 'TCP':
+            if pkt.proto == "TCP":
                 conn_pid = self._get_pid_port_tcp(pkt.sport)
-            elif pkt.proto == 'UDP':
+            elif pkt.proto == "UDP":
                 conn_pid = self._get_pid_port_udp(pkt.sport)
 
             if conn_pid:
@@ -450,7 +440,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
         for adapter in self.get_adapters_info():
             for gateway in self.get_gateways(adapter):
-                if gateway != b'0.0.0.0':
+                if gateway != b"0.0.0.0":
                     return True
         else:
             return False
@@ -510,7 +500,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
     def close_service_handle(self, sc_handle):
 
         if windll.advapi32.CloseServiceHandle(sc_handle) == 0:
-            self.logger.error('Failed to call CloseServiceHandle')
+            self.logger.error("Failed to call CloseServiceHandle")
             return False
 
         return True
@@ -524,17 +514,15 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
     #   _In_ DWORD     dwDesiredAccess
     # );
 
-    def open_service(self, sc_handle, service_name,
-                     dwDesiredAccess=SERVICE_ALL_ACCESS):
+    def open_service(self, sc_handle, service_name, dwDesiredAccess=SERVICE_ALL_ACCESS):
 
         if not sc_handle:
             return
 
-        service_handle = windll.advapi32.OpenServiceA(sc_handle, service_name,
-                                                      dwDesiredAccess)
+        service_handle = windll.advapi32.OpenServiceA(sc_handle, service_name, dwDesiredAccess)
 
         if service_handle == 0:
-            self.logger.error('OpenService failed for %s', service_name)
+            self.logger.error("OpenService failed for %s", service_name)
             return
 
         return service_handle
@@ -556,8 +544,13 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         cbBufSize = DWORD(sizeof(SERVICE_STATUS_PROCESS))
         pcbBytesNeeded = DWORD()
 
-        if windll.advapi32.QueryServiceStatusEx(service_handle, SC_STATUS_PROCESS_INFO, byref(lpBuffer), cbBufSize, byref(pcbBytesNeeded)) == 0:
-            self.logger.error('Failed to call QueryServiceStatusEx')
+        if (
+            windll.advapi32.QueryServiceStatusEx(
+                service_handle, SC_STATUS_PROCESS_INFO, byref(lpBuffer), cbBufSize, byref(pcbBytesNeeded)
+            )
+            == 0
+        ):
+            self.logger.error("Failed to call QueryServiceStatusEx")
             return
 
         return lpBuffer
@@ -576,7 +569,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         lpServiceStatus = SERVICE_STATUS_PROCESS()
 
         if windll.advapi32.ControlService(service_handle, dwControl, byref(lpServiceStatus)) == 0:
-            self.logger.error('Failed to call ControlService')
+            self.logger.error("Failed to call ControlService")
             return
 
         return lpServiceStatus
@@ -593,7 +586,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
     def start_service(self, service_handle):
 
         if windll.advapi32.StartServiceA(service_handle, 0, 0) == 0:
-            self.logger.error('Failed to call StartService')
+            self.logger.error("Failed to call StartService")
             return False
 
         else:
@@ -616,18 +609,22 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
     #   _In_opt_  LPCTSTR   lpDisplayName
     # );
 
-    def change_service_config(self, service_handle,
-                              dwStartType=SERVICE_DISABLED):
+    def change_service_config(self, service_handle, dwStartType=SERVICE_DISABLED):
 
-        if windll.advapi32.ChangeServiceConfigA(service_handle, SERVICE_NO_CHANGE, dwStartType, SERVICE_NO_CHANGE, 0, 0, 0, 0, 0, 0, 0) == 0:
-            self.logger.error('Failed to call ChangeServiceConfig')
+        if (
+            windll.advapi32.ChangeServiceConfigA(
+                service_handle, SERVICE_NO_CHANGE, dwStartType, SERVICE_NO_CHANGE, 0, 0, 0, 0, 0, 0, 0
+            )
+            == 0
+        ):
+            self.logger.error("Failed to call ChangeServiceConfig")
             raise WinError(get_last_error())
             return False
 
         else:
             return True
 
-    def start_service_helper(self, service_name='Dnscache'):
+    def start_service_helper(self, service_name="Dnscache"):
 
         sc_handle = None
         service_handle = None
@@ -650,22 +647,19 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
             # Backup enable the service
             try:
-                subprocess.check_call("sc config %s start= auto" %
-                                      service_name, shell=True,
-                                      stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE)
+                subprocess.check_call(
+                    "sc config %s start= auto" % service_name,
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
             except subprocess.CalledProcessError as e:
-                self.logger.error(
-                    'Failed to enable the service %s. (sc config)',
-                    service_name)
+                self.logger.error("Failed to enable the service %s. (sc config)", service_name)
             else:
-                self.logger.debug(
-                    'Successfully enabled the service %s. (sc config)',
-                    service_name)
+                self.logger.debug("Successfully enabled the service %s. (sc config)", service_name)
 
         else:
-            self.logger.debug('Successfully enabled the service %s.',
-                             service_name)
+            self.logger.debug("Successfully enabled the service %s.", service_name)
 
         service_status = self.query_service_status_ex(service_handle)
 
@@ -673,48 +667,41 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
             if not service_status.dwCurrentState in [SERVICE_RUNNING, SERVICE_START_PENDING]:
 
-                    # Start service
+                # Start service
                 if self.start_service(service_handle):
 
-                        # Wait for the service to start
+                    # Wait for the service to start
                     while timeout:
                         timeout -= 1
                         time.sleep(1)
 
-                        service_status = self.query_service_status_ex(
-                            service_handle)
+                        service_status = self.query_service_status_ex(service_handle)
                         if service_status.dwCurrentState == SERVICE_RUNNING:
-                            self.logger.debug(
-                                'Successfully started the service %s.', service_name)
+                            self.logger.debug("Successfully started the service %s.", service_name)
                             break
                     else:
-                        self.logger.error(
-                            'Timed out while trying to start the service %s.', service_name)
+                        self.logger.error("Timed out while trying to start the service %s.", service_name)
                 else:
-                    self.logger.error(
-                        'Failed to start the service %s.', service_name)
+                    self.logger.error("Failed to start the service %s.", service_name)
             else:
-                self.logger.debug(
-                    'Service %s is already running.', service_name)
+                self.logger.debug("Service %s is already running.", service_name)
 
         # As a backup call net stop
         if service_status.dwCurrentState != SERVICE_RUNNING:
 
             try:
-                subprocess.check_call("net start %s" % service_name,
-                                      shell=True, stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE)
+                subprocess.check_call(
+                    "net start %s" % service_name, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
             except subprocess.CalledProcessError as e:
-                self.logger.error(
-                    'Failed to start the service %s. (net stop)', service_name)
+                self.logger.error("Failed to start the service %s. (net stop)", service_name)
             else:
-                self.logger.debug('Successfully started the service %s.',
-                                 service_name)
+                self.logger.debug("Successfully started the service %s.", service_name)
 
         self.close_service_handle(service_handle)
         self.close_service_handle(sc_handle)
 
-    def stop_service_helper(self, service_name='Dnscache'):
+    def stop_service_helper(self, service_name="Dnscache"):
 
         sc_handle = None
         service_handle = None
@@ -739,20 +726,19 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
             # Backup disable the service
             try:
-                subprocess.check_call("sc config %s start= disabled" %
-                                      service_name, shell=True,
-                                      stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE)
+                subprocess.check_call(
+                    "sc config %s start= disabled" % service_name,
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
             except subprocess.CalledProcessError as e:
-                self.logger.error(
-                    'Failed to disable the service %s. (sc config)', service_name)
+                self.logger.error("Failed to disable the service %s. (sc config)", service_name)
             else:
-                self.logger.debug(
-                    'Successfully disabled the service %s. (sc config)', service_name)
+                self.logger.debug("Successfully disabled the service %s. (sc config)", service_name)
 
         else:
-            self.logger.debug(
-                'Successfully disabled the service %s.', service_name)
+            self.logger.debug("Successfully disabled the service %s.", service_name)
 
         service_status = self.query_service_status_ex(service_handle)
 
@@ -768,36 +754,29 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
                         timeout -= 1
                         time.sleep(1)
 
-                        service_status = self.query_service_status_ex(
-                            service_handle)
+                        service_status = self.query_service_status_ex(service_handle)
                         if service_status.dwCurrentState == SERVICE_STOPPED:
-                            self.logger.debug(
-                                'Successfully stopped the service %s.', service_name)
+                            self.logger.debug("Successfully stopped the service %s.", service_name)
                             break
 
                     else:
-                        self.logger.error(
-                            'Timed out while trying to stop the service %s.', service_name)
+                        self.logger.error("Timed out while trying to stop the service %s.", service_name)
                 else:
-                    self.logger.error(
-                        'Failed to stop the service %s.', service_name)
+                    self.logger.error("Failed to stop the service %s.", service_name)
             else:
-                self.logger.debug(
-                    'Service %s is already stopped.', service_name)
+                self.logger.debug("Service %s is already stopped.", service_name)
 
         # As a backup call net stop
         if service_status.dwCurrentState != SERVICE_STOPPED:
 
             try:
-                subprocess.check_call("net stop %s" % service_name,
-                                      shell=True, stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE)
+                subprocess.check_call(
+                    "net stop %s" % service_name, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
             except subprocess.CalledProcessError as e:
-                self.logger.error(
-                    'Failed to stop the service %s. (net stop)', service_name)
+                self.logger.error("Failed to stop the service %s. (net stop)", service_name)
             else:
-                self.logger.debug(
-                    'Successfully stopped the service %s.', service_name)
+                self.logger.debug("Successfully stopped the service %s.", service_name)
 
         self.close_service_handle(service_handle)
         self.close_service_handle(sc_handle)
@@ -824,11 +803,16 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
         TcpTable = MIB_TCPTABLE_OWNER_PID()
 
-        if windll.iphlpapi.GetExtendedTcpTable(byref(TcpTable), byref(dwSize), False, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0) != NO_ERROR:
+        if (
+            windll.iphlpapi.GetExtendedTcpTable(
+                byref(TcpTable), byref(dwSize), False, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0
+            )
+            != NO_ERROR
+        ):
             self.logger.error("Failed to call GetExtendedTcpTable")
             return
 
-        for item in TcpTable.table[:TcpTable.dwNumEntries]:
+        for item in TcpTable.table[: TcpTable.dwNumEntries]:
             yield item
 
     def _get_pid_port_tcp(self, port):
@@ -836,7 +820,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         for item in self.get_extended_tcp_table():
 
             lPort = socket.ntohs(item.dwLocalPort)
-            lAddr = socket.inet_ntoa(struct.pack('L', item.dwLocalAddr))
+            lAddr = socket.inet_ntoa(struct.pack("L", item.dwLocalAddr))
             pid = item.dwOwningPid
 
             if lPort == port:
@@ -862,11 +846,14 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
         UdpTable = MIB_UDPTABLE_OWNER_PID()
 
-        if windll.iphlpapi.GetExtendedUdpTable(byref(UdpTable), byref(dwSize), False,  AF_INET, UDP_TABLE_OWNER_PID, 0) != NO_ERROR:
+        if (
+            windll.iphlpapi.GetExtendedUdpTable(byref(UdpTable), byref(dwSize), False, AF_INET, UDP_TABLE_OWNER_PID, 0)
+            != NO_ERROR
+        ):
             self.logger.error("Failed to call GetExtendedUdpTable")
             return
 
-        for item in UdpTable.table[:UdpTable.dwNumEntries]:
+        for item in UdpTable.table[: UdpTable.dwNumEntries]:
             yield item
 
     def _get_pid_port_udp(self, port):
@@ -874,7 +861,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         for item in self.get_extended_udp_table():
 
             lPort = socket.ntohs(item.dwLocalPort)
-            lAddr = socket.inet_ntoa(struct.pack('L', item.dwLocalAddr))
+            lAddr = socket.inet_ntoa(struct.pack("L", item.dwLocalAddr))
             pid = item.dwOwningPid
 
             if lPort == port:
@@ -897,10 +884,9 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
         if pid == 4:
             # Skip the inevitable errno 87, invalid parameter
-            process_name = 'System'
+            process_name = "System"
         elif pid:
-            hProcess = windll.kernel32.OpenProcess(
-                PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+            hProcess = windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
             if hProcess:
 
                 lpImageFileName = create_string_buffer(MAX_PATH)
@@ -909,8 +895,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
                     # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/3f6cc0e2-1303-4088-a26b-fb9582f29197
                     process_name = os.path.basename(lpImageFileName.value.decode("utf-8"))
                 else:
-                    self.logger.error('Failed to call GetProcessImageFileNameA, %d' %
-                                      (ctypes.GetLastError()))
+                    self.logger.error("Failed to call GetProcessImageFileNameA, %d" % (ctypes.GetLastError()))
 
                 windll.kernel32.CloseHandle(hProcess)
 
@@ -953,15 +938,13 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
         Size = ULONG(0)
 
-        windll.iphlpapi.GetAdaptersAddresses(AF_INET, 0, None, None,
-                                             byref(Size))
+        windll.iphlpapi.GetAdaptersAddresses(AF_INET, 0, None, None, byref(Size))
 
         AdapterAddresses = create_string_buffer(Size.value)
-        pAdapterAddresses = cast(AdapterAddresses,
-                                 POINTER(IP_ADAPTER_ADDRESSES))
+        pAdapterAddresses = cast(AdapterAddresses, POINTER(IP_ADAPTER_ADDRESSES))
 
         if not windll.iphlpapi.GetAdaptersAddresses(AF_INET, 0, None, pAdapterAddresses, byref(Size)) == NO_ERROR:
-            self.logger.error('Failed calling GetAdaptersAddresses')
+            self.logger.error("Failed calling GetAdaptersAddresses")
             return
 
         while pAdapterAddresses:
@@ -1015,7 +998,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         pAdapterInfo = cast(AdapterInfo, POINTER(IP_ADAPTER_INFO))
 
         if not windll.iphlpapi.GetAdaptersInfo(byref(AdapterInfo), byref(OutBufLen)) == NO_ERROR:
-            self.logger.error('Failed calling GetAdaptersInfo')
+            self.logger.error("Failed calling GetAdaptersInfo")
             return
 
         while pAdapterInfo:
@@ -1061,7 +1044,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
 
         for adapter in self.get_adapters_info():
             for gateway in self.get_gateways(adapter):
-                if gateway != '0.0.0.0':
+                if gateway != "0.0.0.0":
                     return next(self.get_ipaddresses(adapter))
         else:
             return None
@@ -1069,7 +1052,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
     def check_ipaddresses_interface(self, adapter):
 
         for ipaddress in self.get_ipaddresses(adapter):
-            if ipaddress != '0.0.0.0':
+            if ipaddress != "0.0.0.0":
                 return True
         else:
             return False
@@ -1087,7 +1070,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         FixedInfo = FIXED_INFO()
 
         if not windll.iphlpapi.GetNetworkParams(byref(FixedInfo), byref(OutBufLen)) == NO_ERROR:
-            self.logger.error('Failed calling GetNetworkParams')
+            self.logger.error("Failed calling GetNetworkParams")
             return None
 
         return FixedInfo
@@ -1114,17 +1097,17 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
     #   _Out_ PDWORD pdwBestIfIndex
     # );
 
-    def get_best_interface(self, ip='8.8.8.8'):
+    def get_best_interface(self, ip="8.8.8.8"):
         BestIfIndex = DWORD()
         DestAddr = socket.inet_aton(ip)
 
         if not windll.iphlpapi.GetBestInterface(DestAddr, byref(BestIfIndex)) == NO_ERROR:
-            self.logger.error('Failed calling GetBestInterface')
+            self.logger.error("Failed calling GetBestInterface")
             return None
 
         return BestIfIndex.value
 
-    def check_best_interface(self, ip='8.8.8.8'):
+    def check_best_interface(self, ip="8.8.8.8"):
         BestIfIndex = DWORD()
         DestAddr = socket.inet_aton(ip)
 
@@ -1134,7 +1117,7 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         return True
 
     # Return the best local IP address to reach defined IP address
-    def get_best_ipaddress(self, ip='8.8.8.8'):
+    def get_best_ipaddress(self, ip="8.8.8.8"):
 
         index = self.get_best_interface(ip)
 
@@ -1166,13 +1149,18 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
         InterfaceLuid = ULONG64()
 
         if not windll.iphlpapi.ConvertInterfaceIndexToLuid(index, byref(InterfaceLuid)) == NO_ERROR:
-            self.logger.error('Failed calling ConvertInterfaceIndexToLuid')
+            self.logger.error("Failed calling ConvertInterfaceIndexToLuid")
             return None
 
         InterfaceName = create_string_buffer(NDIS_IF_MAX_STRING_SIZE + 1)
 
-        if not windll.iphlpapi.ConvertInterfaceLuidToNameA(byref(InterfaceLuid), InterfaceName, NDIS_IF_MAX_STRING_SIZE + 1) == NO_ERROR:
-            self.logger.error('Failed calling ConvertInterfaceLuidToName')
+        if (
+            not windll.iphlpapi.ConvertInterfaceLuidToNameA(
+                byref(InterfaceLuid), InterfaceName, NDIS_IF_MAX_STRING_SIZE + 1
+            )
+            == NO_ERROR
+        ):
+            self.logger.error("Failed calling ConvertInterfaceLuidToName")
             return None
 
         return InterfaceName.value
@@ -1192,24 +1180,20 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
     def notify_ip_change(self, adapter_name):
 
         if windll.dhcpcsvc.DhcpNotifyConfigChange(0, adapter_name, 0, 0, 0, 0, 0) == NO_ERROR:
-            self.logger.debug(
-                'Successfully performed adapter change notification on %s', adapter_name)
+            self.logger.debug("Successfully performed adapter change notification on %s", adapter_name)
         else:
-            self.logger.error('Failed to notify adapter change on %s',
-                              adapter_name)
+            self.logger.error("Failed to notify adapter change on %s", adapter_name)
 
     ###########################################################################
     # DnsFlushResolverCache
     def flush_dns(self):
 
         try:
-            subprocess.check_call(
-                'ipconfig /flushdns', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.check_call("ipconfig /flushdns", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
-            self.logger.error("Failed to flush DNS cache. Local machine may "
-                              "use cached DNS results.")
+            self.logger.error("Failed to flush DNS cache. Local machine may " "use cached DNS results.")
         else:
-            self.logger.debug('Flushed DNS cache.')
+            self.logger.debug("Flushed DNS cache.")
 
     def get_reg_value(self, key, sub_key, value, sam=KEY_READ):
 
@@ -1217,13 +1201,13 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
             handle = OpenKey(key, sub_key, 0, sam)
             [data, regtype] = QueryValueEx(handle, value)
             CloseKey(handle)
-            if data == '':
+            if data == "":
                 raise WindowsError
 
             return data
 
         except WindowsError:
-            self.logger.error('Failed getting registry value %s.', value)
+            self.logger.error("Failed getting registry value %s.", value)
             return None
 
     def set_reg_value(self, key, sub_key, value, data, type=REG_SZ, sam=KEY_WRITE):
@@ -1236,99 +1220,89 @@ class WinUtilMixin(diverterbase.DiverterPerOSDelegate):
             return True
 
         except WindowsError:
-            self.logger.error('Failed setting registry value %s', value)
+            self.logger.error("Failed setting registry value %s", value)
             return False
 
     ###########################################################################
     # Set DNS Server
 
-    def set_dns_server(self, dns_server='127.0.0.1'):
+    def set_dns_server(self, dns_server="127.0.0.1"):
 
         key = HKEY_LOCAL_MACHINE
         sub_key = "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces\\%s"
-        value = 'NameServer'
+        value = "NameServer"
 
         for adapter in self.get_active_ethernet_adapters():
             adapter_name = adapter.AdapterName.decode("utf-8")
             # Preserve existing setting
-            dns_server_backup = self.get_reg_value(key, sub_key %
-                                                   adapter_name, value)
+            dns_server_backup = self.get_reg_value(key, sub_key % adapter_name, value)
 
             # Restore previous value or a blank string if the key was not
             # present
             if dns_server_backup:
-                self.adapters_dns_server_backup[adapter_name] = (
-                    dns_server_backup, adapter.FriendlyName)
+                self.adapters_dns_server_backup[adapter_name] = (dns_server_backup, adapter.FriendlyName)
             else:
-                self.adapters_dns_server_backup[adapter_name] = (
-                    '', adapter.FriendlyName)
+                self.adapters_dns_server_backup[adapter_name] = ("", adapter.FriendlyName)
 
             # Set new dns server value
             if self.set_reg_value(key, sub_key % adapter_name, value, dns_server):
-                self.logger.error('Set DNS server %s on the adapter: %s',
-                                 dns_server, adapter.FriendlyName)
+                self.logger.error("Set DNS server %s on the adapter: %s", dns_server, adapter.FriendlyName)
                 self.notify_ip_change(adapter_name)
             else:
-                self.logger.error(
-                    'Failed to set DNS server %s on the adapter: %s', dns_server, adapter.FriendlyName)
+                self.logger.error("Failed to set DNS server %s on the adapter: %s", dns_server, adapter.FriendlyName)
 
     def restore_dns_server(self):
 
         key = HKEY_LOCAL_MACHINE
         sub_key = "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces\\%s"
-        value = 'NameServer'
+        value = "NameServer"
 
         for adapter_name in self.adapters_dns_server_backup:
 
-            (dns_server,
-             adapter_friendlyname) = self.adapters_dns_server_backup[adapter_name]
+            (dns_server, adapter_friendlyname) = self.adapters_dns_server_backup[adapter_name]
 
             # Restore dns server value
             if self.set_reg_value(key, sub_key % adapter_name, value, dns_server):
-                self.logger.debug('Restored DNS server %s on the adapter: %s',
-                                 dns_server, adapter_friendlyname)
+                self.logger.debug("Restored DNS server %s on the adapter: %s", dns_server, adapter_friendlyname)
             else:
                 self.logger.error(
-                    'Failed to restore DNS server %s on the adapter: %s', dns_server, adapter_friendlyname)
+                    "Failed to restore DNS server %s on the adapter: %s", dns_server, adapter_friendlyname
+                )
 
 
 def test_process_list():
 
     class Test(WinUtilMixin):
-        def __init__(self, name='WinUtil'):
+        def __init__(self, name="WinUtil"):
             self.logger = logging.getLogger(name)
 
     self = Test()
 
     pid = self._get_pid_port_tcp(135)
     if pid:
-        self.logger.info('pid: %d name: %s', pid,
-                         self.get_process_image_filename(pid))
+        self.logger.info("pid: %d name: %s", pid, self.get_process_image_filename(pid))
     else:
-        self.logger.error('failed to get pid for tcp port 135')
+        self.logger.error("failed to get pid for tcp port 135")
 
     pid = self._get_pid_port_udp(123)
     if pid:
-        self.logger.info('pid: %d name: %s', pid,
-                         self.get_process_image_filename(pid))
+        self.logger.info("pid: %d name: %s", pid, self.get_process_image_filename(pid))
     else:
-        self.logger.error('failed to get pid for udp port 123')
+        self.logger.error("failed to get pid for udp port 123")
 
     pid = self._get_pid_port_tcp(1234)
     if not pid:
-        self.logger.info('successfully returned None for unknown tcp port '
-                         '1234')
+        self.logger.info("successfully returned None for unknown tcp port " "1234")
 
     pid = self._get_pid_port_udp(1234)
     if not pid:
-        self.logger.info('successfully returned None for unknown udp port '
-                         '1234')
+        self.logger.info("successfully returned None for unknown udp port " "1234")
 
 
 def test_interfaces_list():
 
     class Test(WinUtilMixin):
-        def __init__(self, name='WinUtil'):
+        def __init__(self, name="WinUtil"):
             self.logger = logging.getLogger(name)
 
     self = Test()
@@ -1337,41 +1311,45 @@ def test_interfaces_list():
     # self.logger.info('ethernet: %s enabled: %s index: %d friendlyname: %s name: %s', adapter.IfType == MIB_IF_TYPE_ETHERNET, adapter.OperStatus == IFOPERSTATUSUP, adapter.IfIndex, adapter.FriendlyName, adapter.AdapterName)
 
     for dns_server in self.get_dns_servers():
-        self.logger.info('dns: %s', dns_server)
+        self.logger.info("dns: %s", dns_server)
 
     for gateway in self.get_gateways():
-        self.logger.info('gateway: %s', gateway)
+        self.logger.info("gateway: %s", gateway)
 
     for adapter in self.get_active_ethernet_adapters():
-        self.logger.info('active ethernet index: %s friendlyname: %s name: %s',
-                         adapter.IfIndex, adapter.FriendlyName, adapter.AdapterName.decode('utf-8'))
+        self.logger.info(
+            "active ethernet index: %s friendlyname: %s name: %s",
+            adapter.IfIndex,
+            adapter.FriendlyName,
+            adapter.AdapterName.decode("utf-8"),
+        )
 
 
 def test_registry_nameserver():
 
     class Test(WinUtilMixin):
-        def __init__(self, name='WinUtil'):
+        def __init__(self, name="WinUtil"):
             self.logger = logging.getLogger(name)
 
     self = Test()
 
     key = HKEY_LOCAL_MACHINE
-    sub_key = 'SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\{cd17d5b5-bf83-44f5-8de7-d988e3db5451}'
-    value = 'NameServer'
-    data = '127.0.0.1'
+    sub_key = "SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\{cd17d5b5-bf83-44f5-8de7-d988e3db5451}"
+    value = "NameServer"
+    data = "127.0.0.1"
 
     data_tmp = self.get_reg_value(key, sub_key, value)
-    self.logger.info('NameServer: %s', data_tmp)
+    self.logger.info("NameServer: %s", data_tmp)
 
     if self.set_reg_value(key, sub_key, value, data):
-        self.logger.info('Successfully set value %s to data %s', value, data)
+        self.logger.info("Successfully set value %s to data %s", value, data)
 
         data_tmp = self.get_reg_value(key, sub_key, value)
-        self.logger.info('Nameserver: %s', data_tmp)
+        self.logger.info("Nameserver: %s", data_tmp)
     else:
-        self.logger.info('Failed to set value %s to data %s', value, data)
+        self.logger.info("Failed to set value %s to data %s", value, data)
 
-    self.notify_ip_change('{cd17d5b5-bf83-44f5-8de7-d988e3db5451}')
+    self.notify_ip_change("{cd17d5b5-bf83-44f5-8de7-d988e3db5451}")
 
     self.flush_dns()
 
@@ -1379,79 +1357,79 @@ def test_registry_nameserver():
 def test_registry_gateway():
 
     class Test(WinUtilMixin):
-        def __init__(self, name='WinUtil'):
+        def __init__(self, name="WinUtil"):
             self.logger = logging.getLogger(name)
 
     self = Test()
 
     key = HKEY_LOCAL_MACHINE
-    sub_key = 'SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\{cd17d5b5-bf83-44f5-8de7-d988e3db5451}'
-    #value = 'NameServer'
-    #data = '127.0.0.1'
+    sub_key = "SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\{cd17d5b5-bf83-44f5-8de7-d988e3db5451}"
+    # value = 'NameServer'
+    # data = '127.0.0.1'
 
-    if self.get_reg_value(key, sub_key, 'DhcpDefaultGateway'):
-        self.logger.info('DefaultGateway is set')
+    if self.get_reg_value(key, sub_key, "DhcpDefaultGateway"):
+        self.logger.info("DefaultGateway is set")
 
     else:
-        ip = self.get_reg_value(key, sub_key, 'Dhcp')
+        ip = self.get_reg_value(key, sub_key, "Dhcp")
         # self.logger
 
-    self.notify_ip_change('{cd17d5b5-bf83-44f5-8de7-d988e3db5451}')
+    self.notify_ip_change("{cd17d5b5-bf83-44f5-8de7-d988e3db5451}")
 
 
 def test_check_connectivity():
 
     class Test(WinUtilMixin):
-        def __init__(self, name='WinUtil'):
+        def __init__(self, name="WinUtil"):
             self.logger = logging.getLogger(name)
 
     self = Test()
 
     if not self.check_gateways():
-        self.logger.warning('No gateways found.')
+        self.logger.warning("No gateways found.")
     else:
-        self.logger.info('Gateways PASS')
+        self.logger.info("Gateways PASS")
 
     if not self.check_active_ethernet_adapters():
-        self.logger.warning('No active ethernet adapters found')
+        self.logger.warning("No active ethernet adapters found")
     else:
-        self.logger.info('Active ethernet PASS')
+        self.logger.info("Active ethernet PASS")
 
     if not self.get_best_interface():
-        self.logger.warning('No routable interface found.')
+        self.logger.warning("No routable interface found.")
     else:
-        self.logger.info('Routable interface PASS')
+        self.logger.info("Routable interface PASS")
 
     if not self.check_dns_servers():
-        self.logger.warning('No DNS servers configured')
+        self.logger.warning("No DNS servers configured")
     else:
-        self.logger.info('DNS server PASS')
+        self.logger.info("DNS server PASS")
 
 
 def test_stop_service():
 
     class Test(WinUtilMixin):
-        def __init__(self, name='WinUtil'):
+        def __init__(self, name="WinUtil"):
             self.logger = logging.getLogger(name)
 
     self = Test()
 
-    self.stop_service_helper('Dnscache')
+    self.stop_service_helper("Dnscache")
 
 
 def test_start_service():
     class Test(WinUtilMixin):
-        def __init__(self, name='WinUtil'):
+        def __init__(self, name="WinUtil"):
             self.logger = logging.getLogger(name)
 
     self = Test()
 
-    self.start_service_helper('Dnscache')
+    self.start_service_helper("Dnscache")
 
 
 def test_get_best_ip():
     class Test(WinUtilMixin):
-        def __init__(self, name='WinUtil'):
+        def __init__(self, name="WinUtil"):
             self.logger = logging.getLogger(name)
 
     self = Test()
@@ -1480,5 +1458,5 @@ def main():
     test_get_best_ip()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/BannerFactory.py
+++ b/fakenet/listeners/BannerFactory.py
@@ -5,11 +5,12 @@ import socket
 import string
 import datetime
 
+
 class Banner(object):
     """Act like a string, but actually get date/time components on the fly.
 
     Returned by BannerFactory.genBanner().
-    
+
     Allows listeners to statically set a banner in their start() procedure for
     libraries like pyftpdlib that expect to be able to use a static string
     value. When the __len__() and __repr__() methods are called, this class
@@ -36,7 +37,7 @@ class Banner(object):
 
         if self.test_pyftpdlib_handler_banner_threshold75:
             self.len_75 = len(self.str_75)
-            self.str_76 = 'a' * 76
+            self.str_76 = "a" * 76
 
         self.banner = banner
         self.insertions = insertions
@@ -58,7 +59,7 @@ class Banner(object):
 
     def __len__(self):
         """Needed for pyftpdlib.
-        
+
         If the length changes between the time when the caller obtains the
         length and the time when the caller obtains the latest generated
         string, then there is not much that could reasonably be done. It would
@@ -94,14 +95,14 @@ class Banner(object):
         banner = self.banner
         banner = banner.format(**self.insertions)
         banner = datetime.datetime.now().strftime(banner)
-        banner = banner.replace('\\n', '\n').replace('\\t', '\t')
+        banner = banner.replace("\\n", "\n").replace("\\t", "\t")
         return banner
 
 
 class BannerFactory(object):
-    def genBanner(self, config, bannerdict, defaultbannerkey='!generic'):
+    def genBanner(self, config, bannerdict, defaultbannerkey="!generic"):
         """Select and initialize a banner.
-        
+
         Supported banner escapes:
             !<key> - Use the banner whose key in bannerdict is <key>
             !random - Use a random banner from bannerdict
@@ -126,35 +127,32 @@ class BannerFactory(object):
             !gethostname - Use the real hostname
         """
 
-        banner = config.get('banner', defaultbannerkey)
-        servername = config.get('servername', 'localhost')
+        banner = config.get("banner", defaultbannerkey)
+        servername = config.get("servername", "localhost")
 
-        if servername.startswith('!'):
+        if servername.startswith("!"):
             servername = servername[1:]
-            if servername.lower() == 'random':
+            if servername.lower() == "random":
                 servername = self.randomizeHostname()
-            elif servername.lower() == 'gethostname':
+            elif servername.lower() == "gethostname":
                 servername = socket.gethostname()
             else:
-                raise ValueError('ServerName config invalid escape: !%s' %
-                        (servername))
+                raise ValueError("ServerName config invalid escape: !%s" % (servername))
 
-        if banner.startswith('!'):
+        if banner.startswith("!"):
             banner = banner[1:]
-            if banner.lower() == 'random':
+            if banner.lower() == "random":
                 banner = random.choice(list(bannerdict.keys()))
             elif banner not in bannerdict:
-                raise ValueError(
-                        'Banner config escape !%s not a valid banner key' %
-                        (banner))
+                raise ValueError("Banner config escape !%s not a valid banner key" % (banner))
 
             banner = bannerdict[banner]
 
-        insertions = {'servername': servername, 'tz': 'UTC'}
+        insertions = {"servername": servername, "tz": "UTC"}
 
         return Banner(banner, insertions)
 
     def randomizeHostname(self):
-        valid_hostname_charset = (string.ascii_letters + string.digits + '-')
+        valid_hostname_charset = string.ascii_letters + string.digits + "-"
         n = random.randint(1, 15)
-        return ''.join(random.choice(valid_hostname_charset) for _ in range(n))
+        return "".join(random.choice(valid_hostname_charset) for _ in range(n))

--- a/fakenet/listeners/DNSListener.py
+++ b/fakenet/listeners/DNSListener.py
@@ -12,7 +12,7 @@ import socket
 
 from . import *
 
-INDENT = '  '
+INDENT = "  "
 
 
 class DNSListener(object):
@@ -29,50 +29,54 @@ class DNSListener(object):
         return confidence + 2
 
     def __init__(
-            self,
-            config={},
-            name='DNSListener',
-            logging_level=logging.INFO,
-            ):
+        self,
+        config={},
+        name="DNSListener",
+        logging_level=logging.INFO,
+    ):
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging_level)
 
         self.config = config
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
-        self.name = 'DNS'
-        self.port = self.config.get('port', 53)
+        self.name = "DNS"
+        self.port = self.config.get("port", 53)
 
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
+            self.logger.debug("  %10s: %s", key, value)
         if self.logger.level == logging.INFO:
-            self.logger.info('Hiding logs from blacklisted processes')
+            self.logger.info("Hiding logs from blacklisted processes")
 
     def start(self):
 
-        # Start UDP listener  
-        if self.config['protocol'].lower() == 'udp':
-            self.logger.debug('Starting UDP ...')
-            self.server = ThreadedUDPServer((self.local_ip, int(self.config.get('port', 53))), self.config, self.logger, UDPHandler)
+        # Start UDP listener
+        if self.config["protocol"].lower() == "udp":
+            self.logger.debug("Starting UDP ...")
+            self.server = ThreadedUDPServer(
+                (self.local_ip, int(self.config.get("port", 53))), self.config, self.logger, UDPHandler
+            )
 
         # Start TCP listener
-        elif self.config['protocol'].lower() == 'tcp':
-            self.logger.debug('Starting TCP ...')
-            self.server = ThreadedTCPServer((self.local_ip, int(self.config.get('port', 53))), self.config, self.logger, TCPHandler)
+        elif self.config["protocol"].lower() == "tcp":
+            self.logger.debug("Starting TCP ...")
+            self.server = ThreadedTCPServer(
+                (self.local_ip, int(self.config.get("port", 53))), self.config, self.logger, TCPHandler
+            )
 
-        self.server.nxdomains = int(self.config.get('nxdomains', 0))
+        self.server.nxdomains = int(self.config.get("nxdomains", 0))
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True
         self.server_thread.start()
 
     def stop(self):
-        self.logger.debug('Stopping...')
-        
+        self.logger.debug("Stopping...")
+
         # Stop listener
         if self.server:
             self.server.shutdown()
@@ -82,7 +86,7 @@ class DNSListener(object):
         self.server.diverterListenerCallbacks = diverterListenerCallbacks
 
 
-class DNSHandler():
+class DNSHandler:
     def log_message(self, log_level, is_process_blacklisted, message, *args):
         """The primary objective of this method is to control the log messages
         generated for requests from blacklisted processes.
@@ -97,61 +101,66 @@ class DNSHandler():
             self.server.logger.log(logging.DEBUG, message, *args)
         else:
             self.server.logger.log(log_level, message, *args)
-           
+
     def parse(self, data):
         response = ""
-        proto = 'TCP' if self.server.socket_type == socket.SOCK_STREAM else 'UDP'
-        is_process_blacklisted, process_name, pid = self.server \
-                                                         .diverterListenerCallbacks \
-                                                         .isProcessBlackListed(
-                                                              proto,
-                                                              sport=self.client_address[1])
+        proto = "TCP" if self.server.socket_type == socket.SOCK_STREAM else "UDP"
+        is_process_blacklisted, process_name, pid = self.server.diverterListenerCallbacks.isProcessBlackListed(
+            proto, sport=self.client_address[1]
+        )
 
         try:
-            # Parse data as DNS        
+            # Parse data as DNS
             d = DNSRecord.parse(data)
 
         except Exception as e:
-            self.log_message(logging.ERROR, is_process_blacklisted, 'Error: Invalid DNS Request')
+            self.log_message(logging.ERROR, is_process_blacklisted, "Error: Invalid DNS Request")
             for line in hexdump_table(data):
                 self.log_message(logging.WARNING, is_process_blacklisted, INDENT + line)
 
-        else:                 
+        else:
             # Only Process DNS Queries
             if QR[d.header.qr] == "QUERY":
-                     
+
                 # Gather query parameters
                 # NOTE: Do not lowercase qname here, because we want to see
                 #       any case request weirdness in the logs.
                 qname = str(d.q.qname)
-                
+
                 # Chop off the last period
-                if qname[-1] == '.': qname = qname[:-1]
+                if qname[-1] == ".":
+                    qname = qname[:-1]
 
                 qtype = QTYPE[d.q.qtype]
                 self.qname = qname
                 self.qtype = qtype
 
                 if process_name is None or pid is None:
-                    self.log_message(logging.INFO, is_process_blacklisted,
-                                      'Received %s request for domain \'%s\'.',
-                                      qtype, qname)
+                    self.log_message(
+                        logging.INFO, is_process_blacklisted, "Received %s request for domain '%s'.", qtype, qname
+                    )
                 else:
-                    self.log_message(logging.INFO, is_process_blacklisted,
-                                     'Received %s request for domain \'%s\' from %s (%s)',
-                                     qtype, qname, process_name, pid)
+                    self.log_message(
+                        logging.INFO,
+                        is_process_blacklisted,
+                        "Received %s request for domain '%s' from %s (%s)",
+                        qtype,
+                        qname,
+                        process_name,
+                        pid,
+                    )
 
                 # Create a custom response to the query
                 response = DNSRecord(DNSHeader(id=d.header.id, bitmap=d.header.bitmap, qr=1, aa=1, ra=1), q=d.q)
 
-                if qtype == 'A':
+                if qtype == "A":
                     # Get fake record from the configuration or use the external address
-                    fake_record = self.server.config.get('responsea', None)
+                    fake_record = self.server.config.get("responsea", None)
 
                     # msftncsi does request ipv6 but we only support v4 for now
-                    #TODO integrate into randomized/custom responses. Keep it simple for now.
-                    if 'dns.msftncsi.com' in qname:
-                        fake_record = '131.107.255.225'
+                    # TODO integrate into randomized/custom responses. Keep it simple for now.
+                    if "dns.msftncsi.com" in qname:
+                        fake_record = "131.107.255.225"
 
                     # Using socket.gethostbyname(socket.gethostname()) will return
                     # 127.0.1.1 on Ubuntu systems that automatically add this entry
@@ -177,118 +186,116 @@ class DNSHandler():
                     # The DNSResponse setting was previously statically set to
                     # 192.0.2.123, which for local scenarios works fine in Windows
                     # standalone use cases because all connections to IP addresses
-                    # are redirected by Diverter. Changing the default setting to 
+                    # are redirected by Diverter. Changing the default setting to
                     #
                     # IPv6 is not yet implemented, but when it is, it will be
                     # necessary to consider how to get similar behavior to
 
-                    if fake_record == 'GetFirstNonLoopback':
+                    if fake_record == "GetFirstNonLoopback":
                         for iface in netifaces.interfaces():
                             for link in netifaces.ifaddresses(iface)[netifaces.AF_INET]:
-                                if 'addr' in link:
-                                    addr = link['addr']
-                                    if not addr.startswith('127.'):
+                                if "addr" in link:
+                                    addr = link["addr"]
+                                    if not addr.startswith("127."):
                                         fake_record = addr
                                         break
-                    elif fake_record == 'GetHostByName' or fake_record is None:
+                    elif fake_record == "GetHostByName" or fake_record is None:
                         fake_record = socket.gethostbyname(socket.gethostname())
 
                     if self.server.nxdomains > 0:
-                        self.log_message(logging.INFO, is_process_blacklisted, 'Ignoring query. NXDomains: %d',
-                                self.server.nxdomains)
+                        self.log_message(
+                            logging.INFO, is_process_blacklisted, "Ignoring query. NXDomains: %d", self.server.nxdomains
+                        )
                         self.server.nxdomains -= 1
                     else:
-                        self.log_message(logging.DEBUG, is_process_blacklisted, 'Responding with \'%s\'',
-                                                 fake_record)
-                        response.add_answer(RR(qname, getattr(QTYPE,qtype), rdata=RDMAP[qtype](fake_record)))
+                        self.log_message(logging.DEBUG, is_process_blacklisted, "Responding with '%s'", fake_record)
+                        response.add_answer(RR(qname, getattr(QTYPE, qtype), rdata=RDMAP[qtype](fake_record)))
 
-                elif qtype == 'MX':
+                elif qtype == "MX":
 
-                    fake_record = self.server.config.get('responsemx', 'mail.evil.com')
+                    fake_record = self.server.config.get("responsemx", "mail.evil.com")
 
                     # dnslib doesn't like trailing dots
-                    if fake_record[-1] == ".": fake_record = fake_record[:-1]
+                    if fake_record[-1] == ".":
+                        fake_record = fake_record[:-1]
 
-                    self.log_message(logging.DEBUG, is_process_blacklisted, 'Responding with \'%s\'',
-                                             fake_record)
-                    response.add_answer(RR(qname, getattr(QTYPE,qtype), rdata=RDMAP[qtype](fake_record)))
+                    self.log_message(logging.DEBUG, is_process_blacklisted, "Responding with '%s'", fake_record)
+                    response.add_answer(RR(qname, getattr(QTYPE, qtype), rdata=RDMAP[qtype](fake_record)))
 
+                elif qtype == "TXT":
 
-                elif qtype == 'TXT':
+                    fake_record = self.server.config.get("responsetxt", "FAKENET")
 
-                    fake_record = self.server.config.get('responsetxt', 'FAKENET')
-
-                    self.log_message(logging.DEBUG, is_process_blacklisted, 'Responding with \'%s\'',
-                                             fake_record)
-                    response.add_answer(RR(qname, getattr(QTYPE,qtype), rdata=RDMAP[qtype](fake_record)))
+                    self.log_message(logging.DEBUG, is_process_blacklisted, "Responding with '%s'", fake_record)
+                    response.add_answer(RR(qname, getattr(QTYPE, qtype), rdata=RDMAP[qtype](fake_record)))
 
                 response = response.pack()
-                
-        return response  
+
+        return response
+
 
 class UDPHandler(DNSHandler, socketserver.BaseRequestHandler):
 
     def handle(self):
 
         try:
-            (data,sk) = self.request
+            (data, sk) = self.request
             response = self.parse(data)
 
             # Collect NBI
-            nbi = {
-                'Query Type': self.qtype,
-                'Domain': self.qname
-                }
-            collect_nbi(self.client_address[1], nbi, 'UDP', 'No',
-                        self.server.diverterListenerCallbacks)
+            nbi = {"Query Type": self.qtype, "Domain": self.qname}
+            collect_nbi(self.client_address[1], nbi, "UDP", "No", self.server.diverterListenerCallbacks)
 
             if response:
                 sk.sendto(response, self.client_address)
 
         except socket.error as msg:
-            self.server.logger.error('Error: %s', msg.strerror or msg)
+            self.server.logger.error("Error: %s", msg.strerror or msg)
 
         except Exception as e:
-            self.server.logger.error('Error: %s', e)
+            self.server.logger.error("Error: %s", e)
+
 
 class TCPHandler(DNSHandler, socketserver.BaseRequestHandler):
 
     def handle(self):
 
         # Timeout connection to prevent hanging
-        self.request.settimeout(int(self.server.config.get('timeout', 5)))
+        self.request.settimeout(int(self.server.config.get("timeout", 5)))
 
         try:
             data = self.request.recv(1024)
-            
+
             # Remove the addition "length" parameter used in the
             # TCP DNS protocol
             data = data[2:]
             response = self.parse(data)
 
             # Collect NBI
-            nbi = {
-                'Query Type': self.qtype,
-                'Domain': self.qname
-                }
-            collect_nbi(self.client_address[1], nbi, 'TCP',
-                        self.server.config.get('usessl'),
-                        self.server.diverterListenerCallbacks)
-            
+            nbi = {"Query Type": self.qtype, "Domain": self.qname}
+            collect_nbi(
+                self.client_address[1],
+                nbi,
+                "TCP",
+                self.server.config.get("usessl"),
+                self.server.diverterListenerCallbacks,
+            )
+
             if response:
                 # Calculate and add the additional "length" parameter
-                # used in TCP DNS protocol 
-                length = binascii.unhexlify("%04x" % len(response))            
-                self.request.sendall(length+response)      
+                # used in TCP DNS protocol
+                length = binascii.unhexlify("%04x" % len(response))
+                self.request.sendall(length + response)
 
         except socket.timeout:
-            self.server.logger.warning('Connection timeout.')
+            self.server.logger.warning("Connection timeout.")
 
         except socket.error as msg:
-            self.server.logger.error('Error: %s', msg.strerror)
+            self.server.logger.error("Error: %s", msg.strerror)
 
         except Exception as e:
-            self.server.logger.error('Error: %s', e)
+            self.server.logger.error("Error: %s", e)
+
 
 class ThreadedUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
 
@@ -298,8 +305,9 @@ class ThreadedUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
         self.logger = logger
         socketserver.UDPServer.__init__(self, server_address, RequestHandlerClass)
 
+
 class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
-    
+
     # Override default value
     allow_reuse_address = True
 
@@ -307,21 +315,23 @@ class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     def __init__(self, server_address, config, logger, RequestHandlerClass):
         self.config = config
         self.logger = logger
-        socketserver.TCPServer.__init__(self,server_address,RequestHandlerClass)
+        socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
+
 
 def hexdump_table(data, length=16):
 
     hexdump_lines = []
     for i in range(0, len(data), 16):
-        chunk = data[i:i+16]
-        hex_line   = ' '.join(["%02X" % ord(b) for b in chunk ] )
-        ascii_line = ''.join([b if ord(b) > 31 and ord(b) < 127 else '.' for b in chunk ] )
-        hexdump_lines.append("%04X: %-*s %s" % (i, length*3, hex_line, ascii_line ))
+        chunk = data[i : i + 16]
+        hex_line = " ".join(["%02X" % ord(b) for b in chunk])
+        ascii_line = "".join([b if ord(b) > 31 and ord(b) < 127 else "." for b in chunk])
+        hexdump_lines.append("%04X: %-*s %s" % (i, length * 3, hex_line, ascii_line))
     return hexdump_lines
+
 
 def collect_nbi(sport, nbi, proto, is_ssl_encrypted, diverterListenerCallbacks):
     # Report diverter everytime we capture an NBI
-    diverterListenerCallbacks.logNbi(sport, nbi, proto, 'DNS', is_ssl_encrypted)
+    diverterListenerCallbacks.logNbi(sport, nbi, proto, "DNS", is_ssl_encrypted)
 
 
 ###############################################################################
@@ -329,39 +339,48 @@ def collect_nbi(sport, nbi, proto, is_ssl_encrypted, diverterListenerCallbacks):
 def test(config):
 
     print("\t[DNSListener] Testing 'google.com' A record.")
-    query = DNSRecord(q=DNSQuestion('google.com',getattr(QTYPE,'A')))
-    answer_pkt = query.send('localhost', int(config.get('port', 53)))
+    query = DNSRecord(q=DNSQuestion("google.com", getattr(QTYPE, "A")))
+    answer_pkt = query.send("localhost", int(config.get("port", 53)))
     answer = DNSRecord.parse(answer_pkt)
 
-    print('-'*80)
+    print("-" * 80)
     print(answer)
-    print('-'*80)
+    print("-" * 80)
 
     print("\t[DNSListener] Testing 'google.com' MX record.")
-    query = DNSRecord(q=DNSQuestion('google.com',getattr(QTYPE,'MX')))
-    answer_pkt = query.send('localhost', int(config.get('port', 53)))
+    query = DNSRecord(q=DNSQuestion("google.com", getattr(QTYPE, "MX")))
+    answer_pkt = query.send("localhost", int(config.get("port", 53)))
     answer = DNSRecord.parse(answer_pkt)
 
-    print('-'*80)
+    print("-" * 80)
     print(answer)
 
     print("\t[DNSListener] Testing 'google.com' TXT record.")
-    query = DNSRecord(q=DNSQuestion('google.com',getattr(QTYPE,'TXT')))
-    answer_pkt = query.send('localhost', int(config.get('port', 53)))
+    query = DNSRecord(q=DNSQuestion("google.com", getattr(QTYPE, "TXT")))
+    answer_pkt = query.send("localhost", int(config.get("port", 53)))
     answer = DNSRecord.parse(answer_pkt)
 
-    print('-'*80)
+    print("-" * 80)
     print(answer)
-    print('-'*80)
+    print("-" * 80)
+
 
 def main():
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
-    
-    config = {'port': '53', 'protocol': 'UDP', 'responsea': '127.0.0.1', 'responsemx': 'mail.bad.com', 'responsetxt': 'FAKENET', 'nxdomains': 3 }
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
 
-    listener = DNSListener(config, logging_level = logging.DEBUG)
+    config = {
+        "port": "53",
+        "protocol": "UDP",
+        "responsea": "127.0.0.1",
+        "responsemx": "mail.bad.com",
+        "responsetxt": "FAKENET",
+        "nxdomains": 3,
+    }
+
+    listener = DNSListener(config, logging_level=logging.DEBUG)
     listener.start()
-
 
     ###########################################################################
     # Run processing
@@ -377,5 +396,6 @@ def main():
     # Run tests
     test(config)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/FTPListener.py
+++ b/fakenet/listeners/FTPListener.py
@@ -20,135 +20,134 @@ from pyftpdlib.servers import ThreadedFTPServer
 
 from . import BannerFactory
 
-FAKEUSER = 'FAKEUSER'
-FAKEPWD  = 'FAKEPWD'
+FAKEUSER = "FAKEUSER"
+FAKEPWD = "FAKEPWD"
 
 
 EXT_FILE_RESPONSE = {
-    '.html': 'FakeNet.html',
-    '.png' : 'FakeNet.png',
-    '.ico' : 'FakeNet.ico',
-    '.jpeg': 'FakeNet.jpg',
-    '.exe' : 'FakeNetMini.exe',
-    '.pdf' : 'FakeNet.pdf',
-    '.xml' : 'FakeNet.html',
-    '.txt' : 'FakeNet.txt',
+    ".html": "FakeNet.html",
+    ".png": "FakeNet.png",
+    ".ico": "FakeNet.ico",
+    ".jpeg": "FakeNet.jpg",
+    ".exe": "FakeNetMini.exe",
+    ".pdf": "FakeNet.pdf",
+    ".xml": "FakeNet.html",
+    ".txt": "FakeNet.txt",
 }
 
 # Adapted from various sources including https://github.com/turbo/openftp4
 BANNERS = {
-    'generic': '{servername} FTP Server',
-    'ncftpd': '{servername} NcFTPD Server (licensed copy) ready.',
-    'unspec1': lambda hostname: 'FTP server ready',
-    'unspec2': lambda hostname: 'FTP server ready %s',
-    'iis': lambda hostname: '%s Microsoft FTP Service',
-    'iis': lambda hostname: '%s Microsoft FTP Service',
-    'iis-3.0': lambda hostname: '%s Microsoft FTP Service (Version 3.0)',
-    'iis-4.0': lambda hostname: '%s Microsoft FTP Service (Version 4.0)',
-    'iis-5.0': lambda hostname: '%s Microsoft FTP Service (Version 5.0)',
-    'iis-6.0': lambda hostname: '%s Microsoft FTP Service (Version 6.0)',
-    'vs-2.0.7': lambda hostname: '(vsFTPd 2.0.7)',
-    'vs-2.1.0': lambda hostname: '(vsFTPd 2.1.0)',
-    'vs-2.1.2': lambda hostname: '(vsFTPd 2.1.2)',
-    'vs-2.1.2': lambda hostname: '(vsFTPd 2.1.2)',
-    'vs-2.2.0': lambda hostname: '(vsFTPd 2.2.0)',
-    'vs-2.2.1': lambda hostname: '(vsFTPd 2.2.1)',
-    'vs-2.2.2': lambda hostname: '(vsFTPd 2.2.2)',
-    'vs-2.3.0': lambda hostname: '(vsFTPd 2.3.0)',
-    'vs-2.3.1': lambda hostname: '(vsFTPd 2.3.1)',
-    'vs-2.3.2': lambda hostname: '(vsFTPd 2.3.2)',
-    'vs-2.3.4': lambda hostname: '(vsFTPd 2.3.4)',
-    'vs-2.3.5': lambda hostname: '(vsFTPd 2.3.5)',
-
-    'wu-2.4(1)': '{servername} (Version wu-2.4(1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4(2)': '{servername} (Version wu-2.4(2) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4(20)': '{servername} (Version wu-2.4(20) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4.2-academ(1)': '{servername} (Version wu-2.4.2-academ (1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4.2-academ[BETA-15](1)': '{servername} (Version wu-2.4.2-academ[BETA-15](1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4.2-academ[BETA-16](1)': '{servername} (Version wu-2.4.2-academ[BETA-16](1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4.2-academ[BETA-18](1)': '{servername} (Version wu-2.4.2-academ[BETA-18](1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4.2-academ[BETA-9](1)': '{servername} (Version wu-2.4.2-academ[BETA-9](1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4.2-VR16(1)': '{servername} (Version wu-2.4.2-VR16(1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4.2-VR17(1)': '{servername} (Version wu-2.4.2-VR17(1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4(3)': '{servername} (Version wu-2.4(3) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4(4)': '{servername} (Version wu-2.4(4) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.4(6)': '{servername} (Version wu-2.4(6) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.5.0(1)': '{servername} (Version wu-2.5.0(1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.0(1)': '{servername} (Version wu-2.6.0(1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.0(2)': '{servername} (Version wu-2.6.0(2) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.0(4)': '{servername} (Version wu-2.6.0(4) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.0(5)': '{servername} (Version wu-2.6.0(5) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.0(7)': '{servername} (Version wu-2.6.0(7) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-0.6x.21': '{servername} (Version wu-2.6.1-0.6x.21 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1(1)': '{servername} (Version wu-2.6.1(1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1(12)': '{servername} (Version wu-2.6.1(12) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-16': '{servername} (Version wu-2.6.1-16 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-16.7x.1': '{servername} (Version wu-2.6.1-16.7x.1 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-18': '{servername} (Version wu-2.6.1-18 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1(2)': '{servername} (Version wu-2.6.1(2) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-20': '{servername} (Version wu-2.6.1-20 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-21': '{servername} (Version wu-2.6.1-21 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-23.2': '{servername} (Version wu-2.6.1-23.2 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-24': '{servername} (Version wu-2.6.1-24 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1-24.1': '{servername} (Version wu-2.6.1-24.1 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.1(3)': '{servername} (Version wu-2.6.1(3) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(1)': '{servername} (Version wu-2.6.2(1) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(11)': '{servername} (Version wu-2.6.2(11) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-11.1204.1ubuntu': '{servername} (Version wu-2.6.2-11.1204.1ubuntu %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-11.71.1': '{servername} (Version wu-2.6.2-11.71.1 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-11.72.1': '{servername} (Version wu-2.6.2-11.72.1 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-11.73.1': '{servername} (Version wu-2.6.2-11.73.1 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-11.73.1mdk': '{servername} (Version wu-2.6.2-11.73.1mdk %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-12': '{servername} (Version wu-2.6.2-12 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-12.1.co5.PROX': '{servername} (Version wu-2.6.2-12.1.co5.PROX %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-12.rhel2': '{servername} (Version wu-2.6.2-12.rhel2 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(13)': '{servername} (Version wu-2.6.2(13) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2.1(5)': '{servername} (Version wu-2.6.2.1(5) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(15)': '{servername} (Version wu-2.6.2(15) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-15.7x.legacy': '{servername} (Version wu-2.6.2-15.7x.legacy %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-15.7x.PROX': '{servername} (Version wu-2.6.2-15.7x.PROX %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(16)': '{servername} (Version wu-2.6.2(16) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(2)': '{servername} (Version wu-2.6.2(2) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(3)': '{servername} (Version wu-2.6.2(3) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(4)': '{servername} (Version wu-2.6.2(4) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-468': '{servername} (Version wu-2.6.2-468 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(47)': '{servername} (Version wu-2.6.2(47) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(48)': '{servername} (Version wu-2.6.2(48) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2-5': '{servername} (Version wu-2.6.2-5 %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(5)': '{servername} (Version wu-2.6.2(5) %a %b %d %H:%M:%S {tz} %Y) ready.',
-    'wu-2.6.2(52)': '{servername} (Version wu-2.6.2(52) %a %b %d %H:%M:%S {tz} %Y) ready.',
-
-    'ws_ftp-2.0.4': '{servername} V2 WS_FTP Server 2.0.4 (0)',
-    'ws_ftp-3.1.3': '{servername} V2 WS_FTP Server 3.1.3 (0)',
-    'ws_ftp-5.0.5': '{servername} V2 WS_FTP Server 5.0.5 (0)',
-    'ws_ftp-7.5.1': '{servername} V2 WS_FTP Server 7.5.1(0)',
-    'ws_ftp-7.7': '{servername} V2 WS_FTP Server 7.7(0)',
-    'ws_ftp-1.0.3 ': '{servername} X2 WS_FTP Server 1.0.3 (0)',
-    'ws_ftp-1.0.5 ': '{servername} X2 WS_FTP Server 1.0.5 (0)',
-    'ws_ftp-2.0.0 ': '{servername} X2 WS_FTP Server 2.0.0 (0)',
-    'ws_ftp-2.0.3 ': '{servername} X2 WS_FTP Server 2.0.3 (0)',
-    'ws_ftp-3.00 ': '{servername} X2 WS_FTP Server 3.00 (0)',
-    'ws_ftp-3.1.3 ': '{servername} X2 WS_FTP Server 3.1.3 (0)',
-    'ws_ftp-4.0.0 ': '{servername} X2 WS_FTP Server 4.0.0 (0)',
-    'ws_ftp-4.0.2 ': '{servername} X2 WS_FTP Server 4.0.2 (0)',
-    'ws_ftp-5.0.0 ': '{servername} X2 WS_FTP Server 5.0.0 (0)',
-    'ws_ftp-5.0.2 ': '{servername} X2 WS_FTP Server 5.0.2 (0)',
-    'ws_ftp-5.0.4 ': '{servername} X2 WS_FTP Server 5.0.4 (0)',
-    'ws_ftp-5.0.5 ': '{servername} X2 WS_FTP Server 5.0.5 (0)',
-    'ws_ftp-6.0': '{servername} X2 WS_FTP Server 6.0(0)',
-    'ws_ftp-6.1': '{servername} X2 WS_FTP Server 6.1(0)',
-    'ws_ftp-6.1.1': '{servername} X2 WS_FTP Server 6.1.1(0)',
-    'ws_ftp-7.0': '{servername} X2 WS_FTP Server 7.0(0)',
-    'ws_ftp-7.1': '{servername} X2 WS_FTP Server 7.1(0)',
-    'ws_ftp-7.5': '{servername} X2 WS_FTP Server 7.5(0)',
-    'ws_ftp-7.5.1': '{servername} X2 WS_FTP Server 7.5.1(0)',
-    'ws_ftp-7.6': '{servername} X2 WS_FTP Server 7.6(0)',
-    'ws_ftp-7.6': '{servername} X2 WS_FTP Server 7.6(0) FIPS',
-    'ws_ftp-7.6.2': '{servername} X2 WS_FTP Server 7.6.2(0)',
-    'ws_ftp-7.6.2-fips': '{servername} X2 WS_FTP Server 7.6.2(0) FIPS',
-    'ws_ftp-7.6.3': '{servername} X2 WS_FTP Server 7.6.3(0)',
-    'ws_ftp-7.7': '{servername} X2 WS_FTP Server 7.7(0)',
+    "generic": "{servername} FTP Server",
+    "ncftpd": "{servername} NcFTPD Server (licensed copy) ready.",
+    "unspec1": lambda hostname: "FTP server ready",
+    "unspec2": lambda hostname: "FTP server ready %s",
+    "iis": lambda hostname: "%s Microsoft FTP Service",
+    "iis": lambda hostname: "%s Microsoft FTP Service",
+    "iis-3.0": lambda hostname: "%s Microsoft FTP Service (Version 3.0)",
+    "iis-4.0": lambda hostname: "%s Microsoft FTP Service (Version 4.0)",
+    "iis-5.0": lambda hostname: "%s Microsoft FTP Service (Version 5.0)",
+    "iis-6.0": lambda hostname: "%s Microsoft FTP Service (Version 6.0)",
+    "vs-2.0.7": lambda hostname: "(vsFTPd 2.0.7)",
+    "vs-2.1.0": lambda hostname: "(vsFTPd 2.1.0)",
+    "vs-2.1.2": lambda hostname: "(vsFTPd 2.1.2)",
+    "vs-2.1.2": lambda hostname: "(vsFTPd 2.1.2)",
+    "vs-2.2.0": lambda hostname: "(vsFTPd 2.2.0)",
+    "vs-2.2.1": lambda hostname: "(vsFTPd 2.2.1)",
+    "vs-2.2.2": lambda hostname: "(vsFTPd 2.2.2)",
+    "vs-2.3.0": lambda hostname: "(vsFTPd 2.3.0)",
+    "vs-2.3.1": lambda hostname: "(vsFTPd 2.3.1)",
+    "vs-2.3.2": lambda hostname: "(vsFTPd 2.3.2)",
+    "vs-2.3.4": lambda hostname: "(vsFTPd 2.3.4)",
+    "vs-2.3.5": lambda hostname: "(vsFTPd 2.3.5)",
+    "wu-2.4(1)": "{servername} (Version wu-2.4(1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4(2)": "{servername} (Version wu-2.4(2) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4(20)": "{servername} (Version wu-2.4(20) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4.2-academ(1)": "{servername} (Version wu-2.4.2-academ (1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4.2-academ[BETA-15](1)": "{servername} (Version wu-2.4.2-academ[BETA-15](1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4.2-academ[BETA-16](1)": "{servername} (Version wu-2.4.2-academ[BETA-16](1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4.2-academ[BETA-18](1)": "{servername} (Version wu-2.4.2-academ[BETA-18](1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4.2-academ[BETA-9](1)": "{servername} (Version wu-2.4.2-academ[BETA-9](1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4.2-VR16(1)": "{servername} (Version wu-2.4.2-VR16(1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4.2-VR17(1)": "{servername} (Version wu-2.4.2-VR17(1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4(3)": "{servername} (Version wu-2.4(3) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4(4)": "{servername} (Version wu-2.4(4) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.4(6)": "{servername} (Version wu-2.4(6) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.5.0(1)": "{servername} (Version wu-2.5.0(1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.0(1)": "{servername} (Version wu-2.6.0(1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.0(2)": "{servername} (Version wu-2.6.0(2) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.0(4)": "{servername} (Version wu-2.6.0(4) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.0(5)": "{servername} (Version wu-2.6.0(5) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.0(7)": "{servername} (Version wu-2.6.0(7) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-0.6x.21": "{servername} (Version wu-2.6.1-0.6x.21 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1(1)": "{servername} (Version wu-2.6.1(1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1(12)": "{servername} (Version wu-2.6.1(12) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-16": "{servername} (Version wu-2.6.1-16 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-16.7x.1": "{servername} (Version wu-2.6.1-16.7x.1 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-18": "{servername} (Version wu-2.6.1-18 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1(2)": "{servername} (Version wu-2.6.1(2) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-20": "{servername} (Version wu-2.6.1-20 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-21": "{servername} (Version wu-2.6.1-21 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-23.2": "{servername} (Version wu-2.6.1-23.2 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-24": "{servername} (Version wu-2.6.1-24 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1-24.1": "{servername} (Version wu-2.6.1-24.1 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.1(3)": "{servername} (Version wu-2.6.1(3) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(1)": "{servername} (Version wu-2.6.2(1) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(11)": "{servername} (Version wu-2.6.2(11) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-11.1204.1ubuntu": "{servername} (Version wu-2.6.2-11.1204.1ubuntu %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-11.71.1": "{servername} (Version wu-2.6.2-11.71.1 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-11.72.1": "{servername} (Version wu-2.6.2-11.72.1 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-11.73.1": "{servername} (Version wu-2.6.2-11.73.1 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-11.73.1mdk": "{servername} (Version wu-2.6.2-11.73.1mdk %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-12": "{servername} (Version wu-2.6.2-12 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-12.1.co5.PROX": "{servername} (Version wu-2.6.2-12.1.co5.PROX %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-12.rhel2": "{servername} (Version wu-2.6.2-12.rhel2 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(13)": "{servername} (Version wu-2.6.2(13) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2.1(5)": "{servername} (Version wu-2.6.2.1(5) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(15)": "{servername} (Version wu-2.6.2(15) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-15.7x.legacy": "{servername} (Version wu-2.6.2-15.7x.legacy %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-15.7x.PROX": "{servername} (Version wu-2.6.2-15.7x.PROX %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(16)": "{servername} (Version wu-2.6.2(16) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(2)": "{servername} (Version wu-2.6.2(2) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(3)": "{servername} (Version wu-2.6.2(3) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(4)": "{servername} (Version wu-2.6.2(4) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-468": "{servername} (Version wu-2.6.2-468 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(47)": "{servername} (Version wu-2.6.2(47) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(48)": "{servername} (Version wu-2.6.2(48) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2-5": "{servername} (Version wu-2.6.2-5 %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(5)": "{servername} (Version wu-2.6.2(5) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "wu-2.6.2(52)": "{servername} (Version wu-2.6.2(52) %a %b %d %H:%M:%S {tz} %Y) ready.",
+    "ws_ftp-2.0.4": "{servername} V2 WS_FTP Server 2.0.4 (0)",
+    "ws_ftp-3.1.3": "{servername} V2 WS_FTP Server 3.1.3 (0)",
+    "ws_ftp-5.0.5": "{servername} V2 WS_FTP Server 5.0.5 (0)",
+    "ws_ftp-7.5.1": "{servername} V2 WS_FTP Server 7.5.1(0)",
+    "ws_ftp-7.7": "{servername} V2 WS_FTP Server 7.7(0)",
+    "ws_ftp-1.0.3 ": "{servername} X2 WS_FTP Server 1.0.3 (0)",
+    "ws_ftp-1.0.5 ": "{servername} X2 WS_FTP Server 1.0.5 (0)",
+    "ws_ftp-2.0.0 ": "{servername} X2 WS_FTP Server 2.0.0 (0)",
+    "ws_ftp-2.0.3 ": "{servername} X2 WS_FTP Server 2.0.3 (0)",
+    "ws_ftp-3.00 ": "{servername} X2 WS_FTP Server 3.00 (0)",
+    "ws_ftp-3.1.3 ": "{servername} X2 WS_FTP Server 3.1.3 (0)",
+    "ws_ftp-4.0.0 ": "{servername} X2 WS_FTP Server 4.0.0 (0)",
+    "ws_ftp-4.0.2 ": "{servername} X2 WS_FTP Server 4.0.2 (0)",
+    "ws_ftp-5.0.0 ": "{servername} X2 WS_FTP Server 5.0.0 (0)",
+    "ws_ftp-5.0.2 ": "{servername} X2 WS_FTP Server 5.0.2 (0)",
+    "ws_ftp-5.0.4 ": "{servername} X2 WS_FTP Server 5.0.4 (0)",
+    "ws_ftp-5.0.5 ": "{servername} X2 WS_FTP Server 5.0.5 (0)",
+    "ws_ftp-6.0": "{servername} X2 WS_FTP Server 6.0(0)",
+    "ws_ftp-6.1": "{servername} X2 WS_FTP Server 6.1(0)",
+    "ws_ftp-6.1.1": "{servername} X2 WS_FTP Server 6.1.1(0)",
+    "ws_ftp-7.0": "{servername} X2 WS_FTP Server 7.0(0)",
+    "ws_ftp-7.1": "{servername} X2 WS_FTP Server 7.1(0)",
+    "ws_ftp-7.5": "{servername} X2 WS_FTP Server 7.5(0)",
+    "ws_ftp-7.5.1": "{servername} X2 WS_FTP Server 7.5.1(0)",
+    "ws_ftp-7.6": "{servername} X2 WS_FTP Server 7.6(0)",
+    "ws_ftp-7.6": "{servername} X2 WS_FTP Server 7.6(0) FIPS",
+    "ws_ftp-7.6.2": "{servername} X2 WS_FTP Server 7.6.2(0)",
+    "ws_ftp-7.6.2-fips": "{servername} X2 WS_FTP Server 7.6.2(0) FIPS",
+    "ws_ftp-7.6.3": "{servername} X2 WS_FTP Server 7.6.3(0)",
+    "ws_ftp-7.7": "{servername} X2 WS_FTP Server 7.7(0)",
 }
+
 
 class FakeFTPHandler(FTPHandler, object):
 
@@ -156,14 +155,14 @@ class FakeFTPHandler(FTPHandler, object):
 
         # Dynamically add user to authorizer
         if not self.authorizer.has_user(self.username):
-            self.authorizer.add_user(self.username, line, self.ftproot_path, 'elradfmwM')
+            self.authorizer.add_user(self.username, line, self.ftproot_path, "elradfmwM")
 
         # Collect NBIs
         nbi = {"Command": "PASS", "Username": self.username, "Password": line}
-        collect_nbi(self.remote_port, nbi, self.server.config.get('usessl'),
-                    self.server.diverterListenerCallbacks)
+        collect_nbi(self.remote_port, nbi, self.server.config.get("usessl"), self.server.diverterListenerCallbacks)
 
         return super(FakeFTPHandler, self).ftp_PASS(line)
+
 
 class TLS_FakeFTPHandler(TLS_FTPHandler, object):
 
@@ -171,14 +170,14 @@ class TLS_FakeFTPHandler(TLS_FTPHandler, object):
 
         # Dynamically add user to authorizer
         if not self.authorizer.has_user(self.username):
-            self.authorizer.add_user(self.username, line, self.ftproot_path, 'elradfmwM')
+            self.authorizer.add_user(self.username, line, self.ftproot_path, "elradfmwM")
 
         # Collect NBIs
         nbi = {"Command": "PASS", "Username": self.username, "Password": line}
-        collect_nbi(self.remote_port, nbi, self.server.config.get('usessl'),
-                    self.server.diverterListenerCallbacks)
+        collect_nbi(self.remote_port, nbi, self.server.config.get("usessl"), self.server.diverterListenerCallbacks)
 
         return super(TLS_FakeFTPHandler, self).ftp_PASS(line)
+
 
 class FakeFS(AbstractedFS):
 
@@ -186,9 +185,12 @@ class FakeFS(AbstractedFS):
 
         # Collect NBIs
         nbi = {"Command": "RETR", "Filename": filename, "Mode": mode}
-        collect_nbi(self.cmd_channel.remote_port, nbi,
-                    self.cmd_channel.server.config.get('usessl'),
-                    self.cmd_channel.server.diverterListenerCallbacks)
+        collect_nbi(
+            self.cmd_channel.remote_port,
+            nbi,
+            self.cmd_channel.server.config.get("usessl"),
+            self.cmd_channel.server.diverterListenerCallbacks,
+        )
 
         # If virtual filename does not exist return a default file based on extention
         if not self.lexists(filename):
@@ -196,7 +198,9 @@ class FakeFS(AbstractedFS):
             file_basename, file_extension = os.path.splitext(filename)
 
             # Calculate absolute path to a fake file
-            filename = os.path.join(os.path.dirname(filename), EXT_FILE_RESPONSE.get(file_extension.lower(), 'FakeNetMini.exe'))
+            filename = os.path.join(
+                os.path.dirname(filename), EXT_FILE_RESPONSE.get(file_extension.lower(), "FakeNetMini.exe")
+            )
 
         return super(FakeFS, self).open(filename, mode)
 
@@ -204,13 +208,16 @@ class FakeFS(AbstractedFS):
 
         # Collect NBIs
         nbi = {"Command": "CWD", "Path": path}
-        collect_nbi(self.cmd_channel.remote_port, nbi,
-                    self.cmd_channel.server.config.get('usessl'),
-                    self.cmd_channel.server.diverterListenerCallbacks)
+        collect_nbi(
+            self.cmd_channel.remote_port,
+            nbi,
+            self.cmd_channel.server.config.get("usessl"),
+            self.cmd_channel.server.diverterListenerCallbacks,
+        )
 
         # If virtual directory does not exist change to the current directory
         if not self.lexists(path):
-            path = '.'
+            path = "."
 
         return super(FakeFS, self).chdir(path)
 
@@ -218,12 +225,15 @@ class FakeFS(AbstractedFS):
 
         # Collect NBIs
         actual_ftp_path = self.fs2ftp(path)
-        if actual_ftp_path.startswith('/'):
-            actual_ftp_path = actual_ftp_path[1:] # remove leading '/'
+        if actual_ftp_path.startswith("/"):
+            actual_ftp_path = actual_ftp_path[1:]  # remove leading '/'
         nbi = {"Command": "DELETE", "Filename": actual_ftp_path}
-        collect_nbi(self.cmd_channel.remote_port, nbi,
-                    self.cmd_channel.server.config.get('usessl'),
-                    self.cmd_channel.server.diverterListenerCallbacks)
+        collect_nbi(
+            self.cmd_channel.remote_port,
+            nbi,
+            self.cmd_channel.server.config.get("usessl"),
+            self.cmd_channel.server.diverterListenerCallbacks,
+        )
 
         # Don't remove anything
         pass
@@ -232,15 +242,19 @@ class FakeFS(AbstractedFS):
 
         # Collect NBIs
         actual_ftp_path = self.fs2ftp(path)
-        if actual_ftp_path.startswith('/'):
-            actual_ftp_path = actual_ftp_path[1:] # remove leading '/'
+        if actual_ftp_path.startswith("/"):
+            actual_ftp_path = actual_ftp_path[1:]  # remove leading '/'
         nbi = {"Command": "RMD", "Directory": actual_ftp_path}
-        collect_nbi(self.cmd_channel.remote_port, nbi,
-                    self.cmd_channel.server.config.get('usessl'),
-                    self.cmd_channel.server.diverterListenerCallbacks)
+        collect_nbi(
+            self.cmd_channel.remote_port,
+            nbi,
+            self.cmd_channel.server.config.get("usessl"),
+            self.cmd_channel.server.diverterListenerCallbacks,
+        )
 
         # Don't remove anything
         pass
+
 
 class FTPListener(object):
 
@@ -249,15 +263,36 @@ class FTPListener(object):
         # See RFC5797 for full command list. Many of these commands are not likely
         # to be used but are included in case malware uses FTP in unexpected ways
         base_ftp_commands = [
-            b'abor', b'acct', b'allo', b'appe', b'cwd', b'dele', b'help', b'list', b'mode',
-            b'nlst', b'noop', b'pass', b'pasv', b'port', b'quit', b'rein', b'rest', b'retr',
-            b'rnfr', b'rnto', b'site', b'stat', b'stor', b'stru', b'type', b'user'
+            b"abor",
+            b"acct",
+            b"allo",
+            b"appe",
+            b"cwd",
+            b"dele",
+            b"help",
+            b"list",
+            b"mode",
+            b"nlst",
+            b"noop",
+            b"pass",
+            b"pasv",
+            b"port",
+            b"quit",
+            b"rein",
+            b"rest",
+            b"retr",
+            b"rnfr",
+            b"rnto",
+            b"site",
+            b"stat",
+            b"stor",
+            b"stru",
+            b"type",
+            b"user",
         ]
-        opt_ftp_commands = [
-            b'cdup', b'mkd', b'pwd', b'rmd', b'smnt', b'stou', b'syst'
-        ]
+        opt_ftp_commands = [b"cdup", b"mkd", b"pwd", b"rmd", b"smnt", b"stou", b"syst"]
 
-        confidence = 1 if dport == 21 else 0 
+        confidence = 1 if dport == 21 else 0
 
         data = data.lstrip().lower()
         for command in base_ftp_commands + opt_ftp_commands:
@@ -266,61 +301,54 @@ class FTPListener(object):
 
         return confidence
 
-    def __init__(self,
-            config,
-            name='FTPListener',
-            logging_level=logging.INFO,
-            running_listeners=None,
-            diverter=None
-            ):
+    def __init__(self, config, name="FTPListener", logging_level=logging.INFO, running_listeners=None, diverter=None):
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging_level)
 
         self.config = config
         self.name = name
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
         self.running_listeners = running_listeners
         self.diverter = diverter
-        self.name = 'FTP'
-        self.port = self.config.get('port', 21)
+        self.name = "FTP"
+        self.port = self.config.get("port", 21)
 
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
+            self.logger.debug("  %10s: %s", key, value)
 
         # Initialize ftproot directory
-        path = self.config.get('ftproot','defaultFiles')
+        path = self.config.get("ftproot", "defaultFiles")
         self.ftproot_path = ListenerBase.abs_config_path(path)
         if self.ftproot_path is None:
-            self.logger.error('Could not locate ftproot directory: %s', path)
+            self.logger.error("Could not locate ftproot directory: %s", path)
             sys.exit(1)
 
     def expand_ports(self, ports_list):
         ports = []
-        for i in ports_list.split(','):
-            if '-' not in i:
+        for i in ports_list.split(","):
+            if "-" not in i:
                 ports.append(int(i))
             else:
-                l,h = list(map(int, i.split('-')))
-                ports+= list(range(l,h+1))
+                l, h = list(map(int, i.split("-")))
+                ports += list(range(l, h + 1))
         return ports
 
     def start(self):
 
         self.authorizer = DummyAuthorizer()
 
+        if self.config.get("usessl") == "Yes":
+            self.logger.debug("Using SSL socket.")
 
-        if self.config.get('usessl') == 'Yes':
-            self.logger.debug('Using SSL socket.')
-
-            keyfile_path = 'listeners/ssl_utils/privkey.pem'
+            keyfile_path = "listeners/ssl_utils/privkey.pem"
             keyfile_path = ListenerBase.abs_config_path(keyfile_path)
             if keyfile_path is None:
-                self.logger.error('Could not locate %s', keyfile_path)
+                self.logger.error("Could not locate %s", keyfile_path)
                 sys.exit(1)
 
             self.handler = TLS_FakeFTPHandler
@@ -335,22 +363,20 @@ class FTPListener(object):
         self.handler.abstracted_fs = FakeFS
 
         self.handler.authorizer = self.authorizer
-        self.handler.passive_ports = self.expand_ports(self.config.get('pasvports', '60000-60010'))
+        self.handler.passive_ports = self.expand_ports(self.config.get("pasvports", "60000-60010"))
 
-
-        self.server = ThreadedFTPServer((self.local_ip, int(self.config['port'])), self.handler)
+        self.server = ThreadedFTPServer((self.local_ip, int(self.config["port"])), self.handler)
         self.server.config = self.config
 
         # Override pyftpdlib logger name
-        logging.getLogger('pyftpdlib').name = self.name
-
+        logging.getLogger("pyftpdlib").name = self.name
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True
         self.server_thread.start()
 
     def stop(self):
-        self.logger.debug('Stopping...')
+        self.logger.debug("Stopping...")
         if self.server:
             self.server.close_all()
 
@@ -361,10 +387,12 @@ class FTPListener(object):
     def acceptDiverterListenerCallbacks(self, diverterListenerCallbacks):
         self.server.diverterListenerCallbacks = diverterListenerCallbacks
 
+
 def collect_nbi(sport, nbi, is_ssl_encrypted, diverterCallbacks):
 
     # Report diverter everytime we capture an NBI
-    diverterCallbacks.logNbi(sport, nbi, 'TCP', 'FTP', is_ssl_encrypted)
+    diverterCallbacks.logNbi(sport, nbi, "TCP", "FTP", is_ssl_encrypted)
+
 
 ###############################################################################
 # Testing code
@@ -373,22 +401,24 @@ def test(config):
     import ftplib
 
     client = ftplib.FTP()
-    client.connect('localhost', int(config.get('port', 21)))
+    client.connect("localhost", int(config.get("port", 21)))
 
-    client.login('user', 'password')
+    client.login("user", "password")
 
-    client.dir('.')
+    client.dir(".")
 
     client.close()
 
-def main():
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
 
-    config = {'port': '21', 'usessl': 'No', 'protocol': 'tcp', 'ftproot': os.path.join('..', 'defaultFiles')}
+def main():
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
+
+    config = {"port": "21", "usessl": "No", "protocol": "tcp", "ftproot": os.path.join("..", "defaultFiles")}
 
     listener = FTPListener(config)
     listener.start()
-
 
     ###########################################################################
     # Run processing
@@ -404,5 +434,6 @@ def main():
     # Run tests
     test(config)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/HTTPListener.py
+++ b/fakenet/listeners/HTTPListener.py
@@ -24,18 +24,18 @@ from .ssl_utils import SSLWrapper
 from . import *
 
 MIME_FILE_RESPONSE = {
-    'text/html':    'FakeNet.html',
-    'image/png':    'FakeNet.png',
-    'image/ico':    'FakeNet.ico',
-    'image/jpeg':   'FakeNet.jpg',
-    'application/octet-stream': 'FakeNetMini.exe',
-    'application/x-msdownload': 'FakeNetMini.exe',
-    'application/x-msdos-program': 'FakeNetMini.exe',
-    'application/pdf': 'FakeNet.pdf',
-    'application/xml': 'FakeNet.html'
+    "text/html": "FakeNet.html",
+    "image/png": "FakeNet.png",
+    "image/ico": "FakeNet.ico",
+    "image/jpeg": "FakeNet.jpg",
+    "application/octet-stream": "FakeNetMini.exe",
+    "application/x-msdownload": "FakeNetMini.exe",
+    "application/x-msdos-program": "FakeNetMini.exe",
+    "application/pdf": "FakeNet.pdf",
+    "application/xml": "FakeNet.html",
 }
 
-INDENT = '  '
+INDENT = "  "
 
 
 def qualify_file_path(filename, fallbackdir):
@@ -44,9 +44,10 @@ def qualify_file_path(filename, fallbackdir):
         if not os.path.exists(path):
             path = os.path.join(fallbackdir, filename)
         if not os.path.exists(path):
-            raise RuntimeError('Cannot find %s' % (filename))
+            raise RuntimeError("Cannot find %s" % (filename))
 
     return path
+
 
 def load_source(modname, filename):
     # Reference: https://docs.python.org/3/whatsnew/3.12.html#imp
@@ -64,61 +65,62 @@ class CustomResponse(object):
     def __init__(self, name, conf, configroot):
         self.name = name
 
-        match_specs = {'httpuris', 'httphosts'}
-        response_specs = {'httprawfile', 'httpstaticstring', 'httpdynamic'}
+        match_specs = {"httpuris", "httphosts"}
+        response_specs = {"httprawfile", "httpstaticstring", "httpdynamic"}
 
         if not match_specs.intersection(conf):
-            raise ValueError('Custom HTTP config section %s lacks '
-                             '%s' % (name, '/'.join(match_specs)))
+            raise ValueError("Custom HTTP config section %s lacks " "%s" % (name, "/".join(match_specs)))
 
         nr_responses = len(response_specs.intersection(conf))
         if nr_responses != 1:
-            raise ValueError('Custom HTTP config section %s has %d of %s' %
-                             (name, nr_responses, '/'.join(response_specs)))
+            raise ValueError(
+                "Custom HTTP config section %s has %d of %s" % (name, nr_responses, "/".join(response_specs))
+            )
 
-        if ('contenttype' in conf) and ('httpstaticstring' not in conf):
-            raise ValueError('Custom HTTP config section %s has ContentType '
-                             'which is only usable with '
-                             'HttpStaticString' % (name))
+        if ("contenttype" in conf) and ("httpstaticstring" not in conf):
+            raise ValueError(
+                "Custom HTTP config section %s has ContentType "
+                "which is only usable with "
+                "HttpStaticString" % (name)
+            )
 
-        self.uris = conf.get('httpuris', {})
+        self.uris = conf.get("httpuris", {})
         if self.uris:
-            self.uris = {u.strip() for u in self.uris.split(',')}
+            self.uris = {u.strip() for u in self.uris.split(",")}
 
-        self.hosts = conf.get('httphosts', {})
+        self.hosts = conf.get("httphosts", {})
         if self.hosts:
-            self.hosts = {h.strip().lower() for h in self.hosts.split(',')}
+            self.hosts = {h.strip().lower() for h in self.hosts.split(",")}
 
-        self.raw_file = qualify_file_path(conf.get('httprawfile'), configroot)
+        self.raw_file = qualify_file_path(conf.get("httprawfile"), configroot)
         if self.raw_file:
-            self.raw_file = open(self.raw_file, 'rb').read()
+            self.raw_file = open(self.raw_file, "rb").read()
 
         self.handler = None
-        pymod_path = qualify_file_path(conf.get('httpdynamic'), configroot)
+        pymod_path = qualify_file_path(conf.get("httpdynamic"), configroot)
         if pymod_path:
-            pymod = load_source('cr_' + self.name, pymod_path)
-            funcname = 'HandleHttp'
-            funcname_legacy = 'HandleRequest'
+            pymod = load_source("cr_" + self.name, pymod_path)
+            funcname = "HandleHttp"
+            funcname_legacy = "HandleRequest"
             if hasattr(pymod, funcname):
                 self.handler = getattr(pymod, funcname)
             elif hasattr(pymod, funcname_legacy):
                 self.handler = getattr(pymod, funcname_legacy)
             else:
-                raise ValueError('Loaded %s module %s has no function %s' %
-                                 ('httpdynamic', conf.get('httpdynamic'),
-                                  funcname))
+                raise ValueError(
+                    "Loaded %s module %s has no function %s" % ("httpdynamic", conf.get("httpdynamic"), funcname)
+                )
 
-        self.static_string = conf.get('httpstaticstring')
+        self.static_string = conf.get("httpstaticstring")
         if self.static_string is not None:
-            self.static_string = self.static_string.replace('\\r\\n', '\r\n')
-        self.content_type = conf.get('ContentType')
+            self.static_string = self.static_string.replace("\\r\\n", "\r\n")
+        self.content_type = conf.get("ContentType")
 
     def checkMatch(self, host, uri):
-        hostmatch = (host.strip().lower() in self.hosts)
-        if (not hostmatch) and (':' in host):
-            host = host[:host.find(':')]
-            hostmatch = (host.strip().lower() in self.hosts)
-
+        hostmatch = host.strip().lower() in self.hosts
+        if (not hostmatch) and (":" in host):
+            host = host[: host.find(":")]
+            hostmatch = host.strip().lower() in self.hosts
 
         urimatch = False
         for match_uri in self.uris:
@@ -135,16 +137,16 @@ class CustomResponse(object):
     def respond(self, req, meth, postdata=None):
         current_time = req.date_time_string()
         if self.raw_file:
-            up_to_date = self.raw_file.replace(b'<RAW-DATE>', current_time.encode("utf-8"))
+            up_to_date = self.raw_file.replace(b"<RAW-DATE>", current_time.encode("utf-8"))
             req.wfile.write(up_to_date)
         elif self.handler:
             self.handler(req, meth, postdata)
         elif self.static_string is not None:
-            up_to_date = self.static_string.replace('<RAW-DATE>', current_time)
+            up_to_date = self.static_string.replace("<RAW-DATE>", current_time)
             req.send_response(200)
-            req.send_header('Content-Length', len(up_to_date))
+            req.send_header("Content-Length", len(up_to_date))
             if self.content_type:
-                req.send_header('Content-Type', self.content_type)
+                req.send_header("Content-Type", self.content_type)
             req.end_headers()
             req.wfile.write(up_to_date.encode("utf-8"))
 
@@ -153,8 +155,7 @@ class HTTPListener(object):
 
     def taste(self, data, dport):
 
-        request_methods = [b'GET', b'HEAD', b'POST', b'PUT', b'DELETE', b'TRACE',
-            b'OPTIONS', b'CONNECT', b'PATCH']
+        request_methods = [b"GET", b"HEAD", b"POST", b"PUT", b"DELETE", b"TRACE", b"OPTIONS", b"CONNECT", b"PATCH"]
 
         confidence = 1 if dport in [80, 443] else 0
 
@@ -166,66 +167,66 @@ class HTTPListener(object):
         return confidence
 
     if not mimetypes.inited:
-        mimetypes.init() # try to read system mime.types
+        mimetypes.init()  # try to read system mime.types
     extensions_map = mimetypes.types_map.copy()
-    extensions_map.update({
-        '': 'text/html', # Default
-        })
+    extensions_map.update(
+        {
+            "": "text/html",  # Default
+        }
+    )
 
     def __init__(
-            self,
-            config={},
-            name='HTTPListener',
-            logging_level=logging.DEBUG,
-            ):
+        self,
+        config={},
+        name="HTTPListener",
+        logging_level=logging.DEBUG,
+    ):
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging_level)
 
         self.config = config
         self.name = name
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
-        self.port = self.config.get('port', 80)
+        self.port = self.config.get("port", 80)
         self.sslwrapper = None
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
+            self.logger.debug("  %10s: %s", key, value)
 
         # Initialize webroot directory
-        path = self.config.get('webroot','defaultFiles')
+        path = self.config.get("webroot", "defaultFiles")
         self.webroot_path = ListenerBase.abs_config_path(path)
         if self.webroot_path is None:
-            self.logger.error('Could not locate webroot directory: %s', path)
+            self.logger.error("Could not locate webroot directory: %s", path)
             sys.exit(1)
 
     def start(self):
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
 
-        self.server = ThreadedHTTPServer((self.local_ip,
-            int(self.config.get('port'))), ThreadedHTTPRequestHandler)
+        self.server = ThreadedHTTPServer((self.local_ip, int(self.config.get("port"))), ThreadedHTTPRequestHandler)
         self.server.logger = self.logger
         self.server.config = self.config
         self.server.webroot_path = self.webroot_path
         self.server.extensions_map = self.extensions_map
 
-        if self.config.get('usessl') == 'Yes':
+        if self.config.get("usessl") == "Yes":
             self.logger.debug("HTTP Listener starting with SSL")
             config = {
-                'cert_dir': self.config.get('cert_dir', 'configs/temp_certs'),
-                'networkmode': self.config.get('networkmode', None),
-                'static_ca': self.config.get('static_ca', 'No'),
-                'ca_cert': self.config.get('ca_cert'),
-                'ca_key': self.config.get('ca_key')
+                "cert_dir": self.config.get("cert_dir", "configs/temp_certs"),
+                "networkmode": self.config.get("networkmode", None),
+                "static_ca": self.config.get("static_ca", "No"),
+                "ca_cert": self.config.get("ca_cert"),
+                "ca_key": self.config.get("ca_key"),
             }
             self.sslwrapper = SSLWrapper(config)
             self.server.sslwrapper = self.sslwrapper
-            self.server.socket = self.server.sslwrapper.wrap_socket(
-                self.server.socket)
+            self.server.socket = self.server.sslwrapper.wrap_socket(self.server.socket)
 
         self.server.custom_responses = []
-        custom = self.config.get('custom')
+        custom = self.config.get("custom")
 
         def checkSetting(d, name, value):
             if name not in d:
@@ -233,7 +234,7 @@ class HTTPListener(object):
             return d[name].lower() == value.lower()
 
         if custom:
-            configdir = self.config.get('configdir')
+            configdir = self.config.get("configdir")
             custom = qualify_file_path(custom, configdir)
             customconf = ConfigParser()
             customconf.read(custom)
@@ -241,13 +242,11 @@ class HTTPListener(object):
             for section in customconf.sections():
                 entries = dict(customconf.items(section))
 
-                if (('instancename' not in entries) and
-                        ('listenertype' not in entries)):
-                    msg = 'Custom Response lacks ListenerType or InstanceName'
+                if ("instancename" not in entries) and ("listenertype" not in entries):
+                    msg = "Custom Response lacks ListenerType or InstanceName"
                     raise RuntimeError(msg)
 
-                if (checkSetting(entries, 'instancename', self.name) or
-                        checkSetting(entries, 'listenertype', 'HTTP')):
+                if checkSetting(entries, "instancename", self.name) or checkSetting(entries, "listenertype", "HTTP"):
                     cr = CustomResponse(section, entries, configdir)
                     self.server.custom_responses.append(cr)
 
@@ -256,7 +255,7 @@ class HTTPListener(object):
         self.server_thread.start()
 
     def stop(self):
-        self.logger.debug('Stopping...')
+        self.logger.debug("Stopping...")
         if self.server:
             self.server.shutdown()
             self.server.server_close()
@@ -269,7 +268,8 @@ class ThreadedHTTPServer(http.server.HTTPServer):
 
     def handle_error(self, request, client_address):
         exctype, value = sys.exc_info()[:2]
-        self.logger.error('Error: %s', value)
+        self.logger.error("Error: %s", value)
+
 
 class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
 
@@ -278,19 +278,19 @@ class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         self.logger = self.server.logger
 
     def version_string(self):
-        return self.server.config.get('version', "FakeNet/1.3")
+        return self.server.config.get("version", "FakeNet/1.3")
 
     def setup(self):
-        self.request.settimeout(int(self.server.config.get('timeout', 10)))
+        self.request.settimeout(int(self.server.config.get("timeout", 10)))
         http.server.BaseHTTPRequestHandler.setup(self)
 
     def doCustomResponse(self, meth, post_data=None):
         uri = self.path
-        host = self.headers.get('host', '')
+        host = self.headers.get("host", "")
 
         for cr in self.server.custom_responses:
             if cr.checkMatch(host, uri):
-                self.server.logger.debug('Invoking custom response %s' % (cr.name))
+                self.server.logger.debug("Invoking custom response %s" % (cr.name))
                 cr.respond(self, meth, post_data)
                 return True
 
@@ -306,7 +306,7 @@ class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         self.collect_nbi(self.requestline, self.headers)
 
         # Prepare response
-        if not self.doCustomResponse('HEAD'):
+        if not self.doCustomResponse("HEAD"):
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
             self.end_headers()
@@ -321,7 +321,7 @@ class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         self.collect_nbi(self.requestline, self.headers)
 
         # Prepare response
-        if not self.doCustomResponse('GET'):
+        if not self.doCustomResponse("GET"):
             # Get response type based on the requested path
             response, response_type = self.get_response(self.path)
 
@@ -334,9 +334,9 @@ class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(response)
 
     def do_POST(self):
-        post_body = b''
+        post_body = b""
 
-        content_len = int(self.headers.get('content-length', 0))
+        content_len = int(self.headers.get("content-length", 0))
         post_body = self.rfile.read(content_len)
 
         # Log request
@@ -344,29 +344,32 @@ class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         for line in str(self.headers).split("\n"):
             self.server.logger.info(INDENT + line)
         for line in post_body.split(b"\n"):
-            self.server.logger.info(INDENT.encode('utf-8') + line)
+            self.server.logger.info(INDENT.encode("utf-8") + line)
 
         # collect nbi
         self.collect_nbi(self.requestline, self.headers, post_body)
 
         # Store HTTP Posts
-        if self.server.config.get('dumphttpposts') and self.server.config['dumphttpposts'].lower() == 'yes':
-                http_filename = "%s_%s.txt" % (self.server.config.get('dumphttppostsfileprefix', 'http'), time.strftime("%Y%m%d_%H%M%S"))
+        if self.server.config.get("dumphttpposts") and self.server.config["dumphttpposts"].lower() == "yes":
+            http_filename = "%s_%s.txt" % (
+                self.server.config.get("dumphttppostsfileprefix", "http"),
+                time.strftime("%Y%m%d_%H%M%S"),
+            )
 
-                self.server.logger.info('Storing HTTP POST headers and data to %s.', http_filename)
-                http_f = open(http_filename, 'wb')
+            self.server.logger.info("Storing HTTP POST headers and data to %s.", http_filename)
+            http_f = open(http_filename, "wb")
 
-                if http_f:
-                    http_f.write(self.requestline.encode('utf-8') + b"\r\n")
-                    http_f.write(str(self.headers).encode('utf-8') + b"\r\n")
-                    http_f.write(post_body)
+            if http_f:
+                http_f.write(self.requestline.encode("utf-8") + b"\r\n")
+                http_f.write(str(self.headers).encode("utf-8") + b"\r\n")
+                http_f.write(post_body)
 
-                    http_f.close()
-                else:
-                    self.server.logger.error('Failed to write HTTP POST headers and data to %s.', http_filename)
+                http_f.close()
+            else:
+                self.server.logger.error("Failed to write HTTP POST headers and data to %s.", http_filename)
 
         # Prepare response
-        if not self.doCustomResponse('GET', post_body):
+        if not self.doCustomResponse("GET", post_body):
             # Get response type based on the requested path
             response, response_type = self.get_response(self.path)
 
@@ -377,7 +380,7 @@ class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
 
             self.wfile.write(response)
-    
+
     def collect_nbi(self, requestline, headers, post_data=None):
         nbi = {}
         method, uri, version = requestline.split(" ")
@@ -393,19 +396,20 @@ class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
             nbi["Request Body"] = post_data
 
         # report diverter everytime we capture an NBI
-        self.server.diverterListenerCallbacks.logNbi(self.client_address[1],
-                nbi, 'TCP', 'HTTP', self.server.config.get('usessl'))
+        self.server.diverterListenerCallbacks.logNbi(
+            self.client_address[1], nbi, "TCP", "HTTP", self.server.config.get("usessl")
+        )
 
     def get_response(self, path):
         response = "<html><head><title>FakeNet</title><body><h1>FakeNet</h1></body></html>"
-        response_type = 'text/html'
+        response_type = "text/html"
 
-        if path[-1] == '/':
-            response_type = 'text/html'
-            path += 'index.html'
+        if path[-1] == "/":
+            response_type = "text/html"
+            path += "index.html"
         else:
             _, ext = posixpath.splitext(path)
-            response_type = self.server.extensions_map.get(ext, 'text/html')
+            response_type = self.server.extensions_map.get(ext, "text/html")
 
         # Do after checking for trailing '/' since normpath removes it
         response_filename = ListenerBase.safe_join(self.server.webroot_path, path)
@@ -413,25 +417,26 @@ class ThreadedHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         # Check the requested path exists
         if not os.path.exists(response_filename):
 
-            self.server.logger.debug('Could not find path: %s', response_filename)
+            self.server.logger.debug("Could not find path: %s", response_filename)
 
             # Try default MIME file
-            response_filename = os.path.join(self.server.webroot_path, MIME_FILE_RESPONSE.get(response_type, 'FakeNet.html'))
+            response_filename = os.path.join(
+                self.server.webroot_path, MIME_FILE_RESPONSE.get(response_type, "FakeNet.html")
+            )
 
             # Check default MIME file exists
             if not os.path.exists(response_filename):
-                self.server.logger.debug('Could not find path: %s', response_filename)
-                self.server.logger.error('Could not locate requested file or default handler.')
+                self.server.logger.debug("Could not find path: %s", response_filename)
+                self.server.logger.error("Could not locate requested file or default handler.")
                 return (response, response_type)
 
-        self.server.logger.debug('Responding with mime type: %s file: %s',
-                                 response_type, response_filename)
+        self.server.logger.debug("Responding with mime type: %s file: %s", response_type, response_filename)
 
         try:
-            f = open(response_filename, 'rb')
+            f = open(response_filename, "rb")
         except Exception as e:
-            self.server.logger.error('Failed to open response file: %s', response_filename)
-            response_type = 'text/html'
+            self.server.logger.error("Failed to open response file: %s", response_filename)
+            response_type = "text/html"
         else:
             response = f.read()
             f.close()
@@ -448,22 +453,23 @@ def test(config):
 
     import requests
 
-    url = "%s://localhost:%s" % ('http' if config.get('usessl') == 'No' else 'https', int(config.get('port', 8080)))
+    url = "%s://localhost:%s" % ("http" if config.get("usessl") == "No" else "https", int(config.get("port", 8080)))
 
     print("\t[HTTPListener] Testing HEAD request.")
-    print('-'*80)
+    print("-" * 80)
     print(requests.head(url, verify=False, stream=True).text)
-    print('-'*80)
+    print("-" * 80)
 
     print("\t[HTTPListener] Testing GET request.")
-    print('-'*80)
+    print("-" * 80)
     print(requests.get(url, verify=False, stream=True).text)
-    print('-'*80)
+    print("-" * 80)
 
     print("\t[HTTPListener] Testing POST request.")
-    print('-'*80)
-    print(requests.post(url, {'param1':'A'*80, 'param2':'B'*80}, verify=False, stream=True).text)
-    print('-'*80)
+    print("-" * 80)
+    print(requests.post(url, {"param1": "A" * 80, "param2": "B" * 80}, verify=False, stream=True).text)
+    print("-" * 80)
+
 
 def main():
     """
@@ -472,9 +478,11 @@ def main():
        python2 -m fakenet.listeners.HTTPListener
 
     """
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
 
-    config = {'port': '8443', 'usessl': 'Yes', 'webroot': 'fakenet/defaultFiles' }
+    config = {"port": "8443", "usessl": "Yes", "webroot": "fakenet/defaultFiles"}
 
     listener = HTTPListener(config)
     listener.start()
@@ -493,5 +501,6 @@ def main():
     # Run tests
     test(config)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/IRCListener.py
+++ b/fakenet/listeners/IRCListener.py
@@ -15,50 +15,102 @@ from . import BannerFactory
 
 from . import *
 
-RPL_WELCOME = '001'
+RPL_WELCOME = "001"
 SRV_WELCOME = "Welcome to FakeNet."
 
 BANNERS = {
-    'generic': 'Welcome to IRC - {servername} - %a %b %d %H:%M:%S {tz} %Y',
-    'debian-ircd-irc2': (
-        '17/10/2011 11:50\n' +
-        '                         [ Debian GNU/Linux ]\n' +
-        '|------------------------------------------------------------------------|\n' +
-        '| This is Debian\'s default IRCd server configuration for irc2.11. If you |\n' +
-        '| see this and if you are the server administrator, just edit ircd.conf  |\n' +
-        '| and ircd.motd in /etc/ircd.                                            |\n' +
-        '|                                     Martin Loschwitz, 1st January 2005 |\n' +
-        '|------------------------------------------------------------------------|\n')
+    "generic": "Welcome to IRC - {servername} - %a %b %d %H:%M:%S {tz} %Y",
+    "debian-ircd-irc2": (
+        "17/10/2011 11:50\n"
+        + "                         [ Debian GNU/Linux ]\n"
+        + "|------------------------------------------------------------------------|\n"
+        + "| This is Debian's default IRCd server configuration for irc2.11. If you |\n"
+        + "| see this and if you are the server administrator, just edit ircd.conf  |\n"
+        + "| and ircd.motd in /etc/ircd.                                            |\n"
+        + "|                                     Martin Loschwitz, 1st January 2005 |\n"
+        + "|------------------------------------------------------------------------|\n"
+    ),
 }
+
 
 class IRCListener(object):
 
     def taste(self, data, dport):
 
-        # All possible commands are included to account for unanticipated 
+        # All possible commands are included to account for unanticipated
         # malware behavior
-        commands = [ 
-            'ADMIN', 'AWAY', 'CAP', 'CNOTICE', 'CPRIVMSG', 'CONNECT', 'DIE', 
-            'ENCAP', 'ERROR', 'HELP', 'INFO', 'INVITE', 'ISON', 'JOIN', 'KICK', 
-            'KILL', 'KNOCK', 'LINKS', 'LIST', 'LUSERS', 'MODE', 'MOTD', 
-            'NAMES', 'NAMESX', 'NICK', 'NOTICE', 'OPER', 'PART', 'PASS', 
-            'PING', 'PONG', 'PRIVMSG', 'QUIT', 'REHASH', 'RESTART', 'RULES', 
-            'SERVER', 'SERVICE', 'SERVLIST', 'SQUERY', 'SQUIT', 'SETNAME', 
-            'SILENCE', 'STATS', 'SUMMON', 'TIME', 'TOPIC', 'TRACE', 'UHNAMES', 
-            'USER', 'USERHOST', 'USERIP', 'USERS', 'VERSION', 'WALLOPS', 
-            'WATCH', 'WHO', 'WHOIS', 'WHOWAS' 
-            ]
+        commands = [
+            "ADMIN",
+            "AWAY",
+            "CAP",
+            "CNOTICE",
+            "CPRIVMSG",
+            "CONNECT",
+            "DIE",
+            "ENCAP",
+            "ERROR",
+            "HELP",
+            "INFO",
+            "INVITE",
+            "ISON",
+            "JOIN",
+            "KICK",
+            "KILL",
+            "KNOCK",
+            "LINKS",
+            "LIST",
+            "LUSERS",
+            "MODE",
+            "MOTD",
+            "NAMES",
+            "NAMESX",
+            "NICK",
+            "NOTICE",
+            "OPER",
+            "PART",
+            "PASS",
+            "PING",
+            "PONG",
+            "PRIVMSG",
+            "QUIT",
+            "REHASH",
+            "RESTART",
+            "RULES",
+            "SERVER",
+            "SERVICE",
+            "SERVLIST",
+            "SQUERY",
+            "SQUIT",
+            "SETNAME",
+            "SILENCE",
+            "STATS",
+            "SUMMON",
+            "TIME",
+            "TOPIC",
+            "TRACE",
+            "UHNAMES",
+            "USER",
+            "USERHOST",
+            "USERIP",
+            "USERS",
+            "VERSION",
+            "WALLOPS",
+            "WATCH",
+            "WHO",
+            "WHOIS",
+            "WHOWAS",
+        ]
 
         # ubuntu xchat uses 8001
         ports = [194, 6667, list(range(6660, 7001)), 8001]
-        
+
         confidence = 1 if dport in ports else 0
 
         data = data.lstrip()
 
         # remove optional prefix
-        if data.startswith(b':'):
-            data = data.split(b' ')[0].decode()
+        if data.startswith(b":"):
+            data = data.split(b" ")[0].decode()
 
         for command in commands:
             if data.startswith(command):
@@ -67,45 +119,46 @@ class IRCListener(object):
 
         return confidence
 
-    def __init__(self,
-            config,
-            name='IRCListener',
-            logging_level=logging.INFO,
-            ):
+    def __init__(
+        self,
+        config,
+        name="IRCListener",
+        logging_level=logging.INFO,
+    ):
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging_level)
         self.config = config
         self.name = name
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
-        self.name = 'IRC'
-        
-        self.port = self.config.get('port', 6667)
-        self.logger.debug('PORT: %s', self.port)
+        self.name = "IRC"
 
-        self.logger.debug('Starting...')
+        self.port = self.config.get("port", 6667)
+        self.logger.debug("PORT: %s", self.port)
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Starting...")
+
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
+            self.logger.debug("  %10s: %s", key, value)
 
     def start(self):
-        self.logger.debug('Starting...')
-        self.server = ThreadedTCPServer((self.local_ip, int(self.config['port'])), ThreadedTCPRequestHandler)
+        self.logger.debug("Starting...")
+        self.server = ThreadedTCPServer((self.local_ip, int(self.config["port"])), ThreadedTCPRequestHandler)
 
         self.banner = self.genBanner()
         self.server.listener = self
         self.server.logger = self.logger
         self.server.config = self.config
-        self.server.servername = self.config.get('servername', 'localhost')
+        self.server.servername = self.config.get("servername", "localhost")
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True
         self.server_thread.start()
 
     def stop(self):
-        self.logger.debug('Stopping...')
+        self.logger.debug("Stopping...")
         if self.server:
             self.server.shutdown()
             self.server.server_close()
@@ -117,14 +170,15 @@ class IRCListener(object):
     def acceptDiverterListenerCallbacks(self, diverterListenerCallbacks):
         self.server.diverterListenerCallbacks = diverterListenerCallbacks
 
+
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
 
         # Timeout connection to prevent hanging
-        self.request.settimeout(int(self.server.config.get('timeout', 10)))
+        self.request.settimeout(int(self.server.config.get("timeout", 10)))
 
-        self.server.logger.info('Client connected')
+        self.server.logger.info("Client connected")
 
         try:
 
@@ -137,37 +191,34 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
                 elif len(data) > 0:
 
-                    for line in data.split('\n'):
+                    for line in data.split("\n"):
 
                         if line and len(line) > 0:
 
-                            if ' ' in line:
-                                cmd, params = line.split(' ', 1)
+                            if " " in line:
+                                cmd, params = line.split(" ", 1)
                             else:
-                                cmd, params = line, ''
+                                cmd, params = line, ""
 
-                            handler = getattr(self, 'irc_%s' % (cmd.upper()), self.irc_DEFAULT)
+                            handler = getattr(self, "irc_%s" % (cmd.upper()), self.irc_DEFAULT)
                             handler(cmd, params)
 
         except socket.timeout:
-            self.server.logger.warning('Connection timeout')
+            self.server.logger.warning("Connection timeout")
 
         except socket.error as msg:
-            self.server.logger.error('Error: %s', msg.strerror or msg)
+            self.server.logger.error("Error: %s", msg.strerror or msg)
 
         except Exception as e:
-            self.server.logger.error('Error: %s', e)
+            self.server.logger.error("Error: %s", e)
 
     def irc_DEFAULT(self, cmd, params):
-        self.server.logger.info('Client issued an unknown command %s %s', cmd, params)
+        self.server.logger.info("Client issued an unknown command %s %s", cmd, params)
         self.irc_send_server("421", "%s :Unknown command" % cmd)
 
         # Collect NBIs
-        params = None if params == '' else params
-        nbi = {
-            "Command": cmd + ' (Unknown command)',
-            "Params": params
-            }
+        params = None if params == "" else params
+        nbi = {"Command": cmd + " (Unknown command)", "Params": params}
         self.collect_nbi(nbi)
 
     def irc_NICK(self, cmd, params):
@@ -180,118 +231,100 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         self.irc_send_server("376", "%s :End of /MOTD command." % self.nick)
 
         # Collect NBIs
-        params = None if params == '' else params
-        nbi = {
-            "Command": cmd,
-            "Params": params
-            }
+        params = None if params == "" else params
+        nbi = {"Command": cmd, "Params": params}
         self.collect_nbi(nbi)
 
     def irc_USER(self, cmd, params):
-        if params.count(' ') == 3:
+        if params.count(" ") == 3:
 
-            user, mode, unused, realname = params.split(' ', 3)
+            user, mode, unused, realname = params.split(" ", 3)
             self.user = user
             self.mode = mode
             self.realname = realname
-            self.request.sendall(b'')
+            self.request.sendall(b"")
 
             # Collect NBIs
-            nbi = {
-                "Command": cmd,
-                "User": user,
-                "Mode": mode,
-                "Real name": realname
-                }
+            nbi = {"Command": cmd, "User": user, "Mode": mode, "Real name": realname}
             self.collect_nbi(nbi)
 
     def irc_PING(self, cmd, params):
         self.request.sendall((":%s PONG :%s" % (self.server.servername, self.server.servername)).encode())
 
         # Collect NBIs
-        params = None if params == '' else params
-        nbi = {
-            "Command": cmd,
-            "Params": params
-            }
+        params = None if params == "" else params
+        nbi = {"Command": cmd, "Params": params}
         self.collect_nbi(nbi)
-
 
     def irc_JOIN(self, cmd, params):
 
-        if ' ' in params:
-            channel_names, channel_keys = params.split(' ')
+        if " " in params:
+            channel_names, channel_keys = params.split(" ")
 
         else:
             channel_names = params
-            channel_keys  = None
+            channel_keys = None
 
-        for i, channel_name in enumerate(channel_names.split(',')):
+        for i, channel_name in enumerate(channel_names.split(",")):
 
             if channel_keys:
-                self.server.logger.info('Client %s is joining channel %s with key %s', self.nick, channel_name, channel_keys.split(',')[i])
+                self.server.logger.info(
+                    "Client %s is joining channel %s with key %s", self.nick, channel_name, channel_keys.split(",")[i]
+                )
             else:
-                self.server.logger.info('Client %s is joining channel %s with no key', self.nick, channel_name)
-
+                self.server.logger.info("Client %s is joining channel %s with no key", self.nick, channel_name)
 
             self.request.sendall((":root TOPIC %s :FakeNet\r\n" % channel_name).encode())
             self.irc_send_client("JOIN :%s" % channel_name)
 
-            nicks = ['botmaster', 'bot', 'admin', 'root', 'master']
-            self.irc_send_server("353", "%s = %s :%s" % (self.nick, channel_name, ' '.join(nicks)))
+            nicks = ["botmaster", "bot", "admin", "root", "master"]
+            self.irc_send_server("353", "%s = %s :%s" % (self.nick, channel_name, " ".join(nicks)))
             self.irc_send_server("366", "%s %s :End of /NAMES list" % (self.nick, channel_name))
 
             # Send a welcome message
-            self.irc_send_client_custom('botmaster', 'botmaster', self.server.servername, "PRIVMSG %s %s" % (channel_name, "Welcome to the channel! %s" % self.nick))
+            self.irc_send_client_custom(
+                "botmaster",
+                "botmaster",
+                self.server.servername,
+                "PRIVMSG %s %s" % (channel_name, "Welcome to the channel! %s" % self.nick),
+            )
 
             # Collect NBIs
-            nbi = {
-                "Command": cmd,
-                "Channel Names": channel_names,
-                "Channel Keys": channel_keys
-                }
+            nbi = {"Command": cmd, "Channel Names": channel_names, "Channel Keys": channel_keys}
             self.collect_nbi(nbi)
-
 
     def irc_PRIVMSG(self, cmd, params):
 
-        if ' ' in params:
-            target, message = params.split(' ', 1)
+        if " " in params:
+            target, message = params.split(" ", 1)
 
             self.server.logger.info('Client sent message "%s" to %s', message, target)
 
             # Echo the message in the channel back to the user
-            if target[0] in ['#', '$']:
-                self.irc_send_client_custom('botmaster', 'botmaster', self.server.servername, "PRIVMSG %s %s" % (target, message))
+            if target[0] in ["#", "$"]:
+                self.irc_send_client_custom(
+                    "botmaster", "botmaster", self.server.servername, "PRIVMSG %s %s" % (target, message)
+                )
 
             # Echo the private message back to the user
             else:
-                self.irc_send_client_custom(target, target, self.server.servername, "PRIVMSG %s %s" % (self.nick, message))
+                self.irc_send_client_custom(
+                    target, target, self.server.servername, "PRIVMSG %s %s" % (self.nick, message)
+                )
 
             # Collect NBIs
-            nbi = {
-                "Command": cmd,
-                "Target": target,
-                "Message": message
-                }
+            nbi = {"Command": cmd, "Target": target, "Message": message}
             self.collect_nbi(nbi)
-
 
     def irc_NOTICE(self, cmd, params):
         # Collect NBIs
-        nbi = {
-            "Command": cmd,
-            "Params": params
-            }
+        nbi = {"Command": cmd, "Params": params}
         self.collect_nbi(nbi)
         pass
 
     def irc_PART(self, cmd, params):
         # Collect NBIs
-        nbi = {
-            "Command": cmd,
-            "Params": params
-            }
+        nbi = {"Command": cmd, "Params": params}
         self.collect_nbi(nbi)
         pass
 
@@ -308,14 +341,15 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         # Report diverter everytime we capture an NBI
         # We are not handling SSL encrypted requests, so pass
         # is_ssl_encrypted = 'No'
-        self.server.diverterListenerCallbacks.logNbi(self.client_address[1],
-                                                     nbi, 'TCP', 'IRC', 'No')
+        self.server.diverterListenerCallbacks.logNbi(self.client_address[1], nbi, "TCP", "IRC", "No")
+
 
 class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     # Avoid [Errno 98] Address already in use due to TIME_WAIT status on TCP
     # sockets, for details see:
     # https://stackoverflow.com/questions/4465959/python-errno-98-address-already-in-use
     allow_reuse_address = True
+
 
 ###############################################################################
 # Testing code
@@ -324,9 +358,11 @@ def test(config):
 
 
 def main():
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
 
-    config = {'port': '6667', 'usessl': 'No', 'timeout': 10, 'servername': 'localhost' }
+    config = {"port": "6667", "usessl": "No", "timeout": 10, "servername": "localhost"}
 
     listener = IRCListener(config)
     listener.start()
@@ -345,5 +381,6 @@ def main():
     # Run tests
     test(config)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/ListenerBase.py
+++ b/fakenet/listeners/ListenerBase.py
@@ -4,18 +4,20 @@ import logging
 import os
 import sys
 
+
 def safe_join(root, path):
-    """ 
+    """
     Joins a path to a root path, even if path starts with '/', using os.sep
-    """ 
+    """
 
     # prepending a '/' ensures '..' does not traverse past the root
     # of the path
-    if not path.startswith('/'):
-        path = '/' + path
+    if not path.startswith("/"):
+        path = "/" + path
     normpath = os.path.normpath(path)
 
     return root + normpath
+
 
 def abs_config_path(path):
     """
@@ -33,7 +35,7 @@ def abs_config_path(path):
     if os.path.exists(abspath):
         return abspath
 
-    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
         relpath = os.path.join(os.path.dirname(sys.executable), path)
     else:
 

--- a/fakenet/listeners/POPListener.py
+++ b/fakenet/listeners/POPListener.py
@@ -24,16 +24,29 @@ This is a test message with 5 header fields and 4 lines in the message body.
 Your friend,
 Bob\r\n"""
 
+
 class POPListener(object):
 
-    # Once the TCP connection has been established, the POP server initiates 
+    # Once the TCP connection has been established, the POP server initiates
     # the conversation with +OK message. However, if the client connects
     # to a port that is not 110, there is no way for the proxy to know that
     # POP is the protocol until the client sends a message.
     def taste(self, data, dport):
 
-        commands = [ b'QUIT', b'STAT', b'LIST', b'RETR', b'DELE', b'NOOP', b'RSET',
-                b'TOP', b'UIDL', b'USER', b'PASS', b'APOP' ]
+        commands = [
+            b"QUIT",
+            b"STAT",
+            b"LIST",
+            b"RETR",
+            b"DELE",
+            b"NOOP",
+            b"RSET",
+            b"TOP",
+            b"UIDL",
+            b"USER",
+            b"PASS",
+            b"APOP",
+        ]
 
         confidence = 1 if dport == 110 else 0
 
@@ -44,49 +57,52 @@ class POPListener(object):
 
         return confidence
 
-    def __init__(self, 
-            config, 
-            name='POPListener', 
-            logging_level=logging.INFO, 
-            ):
+    def __init__(
+        self,
+        config,
+        name="POPListener",
+        logging_level=logging.INFO,
+    ):
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging_level)
 
         self.config = config
         self.name = name
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
-        self.name = 'POP'
-        self.port = self.config.get('port', 110)
+        self.name = "POP"
+        self.port = self.config.get("port", 110)
 
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
+            self.logger.debug("  %10s: %s", key, value)
 
     def start(self):
-        self.logger.debug('Starting...')
-        
-        self.server = ThreadedTCPServer((self.local_ip, int(self.config['port'])), ThreadedTCPRequestHandler)
+        self.logger.debug("Starting...")
 
-        if self.config.get('usessl') == 'Yes':
-            self.logger.debug('Using SSL socket')
+        self.server = ThreadedTCPServer((self.local_ip, int(self.config["port"])), ThreadedTCPRequestHandler)
 
-            keyfile_path = 'listeners/ssl_utils/privkey.pem'
+        if self.config.get("usessl") == "Yes":
+            self.logger.debug("Using SSL socket")
+
+            keyfile_path = "listeners/ssl_utils/privkey.pem"
             keyfile_path = ListenerBase.abs_config_path(keyfile_path)
             if keyfile_path is None:
-                self.logger.error('Could not locate %s', keyfile_path)
+                self.logger.error("Could not locate %s", keyfile_path)
                 sys.exit(1)
 
-            certfile_path = 'listeners/ssl_utils/server.pem'
+            certfile_path = "listeners/ssl_utils/server.pem"
             certfile_path = ListenerBase.abs_config_path(certfile_path)
             if certfile_path is None:
-                self.logger.error('Could not locate %s', certfile_path)
+                self.logger.error("Could not locate %s", certfile_path)
                 sys.exit(1)
 
-            self.server.socket = ssl.wrap_socket(self.server.socket, keyfile='privkey.pem', certfile='server.pem', server_side=True, ciphers='RSA')
+            self.server.socket = ssl.wrap_socket(
+                self.server.socket, keyfile="privkey.pem", certfile="server.pem", server_side=True, ciphers="RSA"
+            )
 
         self.server.logger = self.logger
         self.server.config = self.config
@@ -96,7 +112,7 @@ class POPListener(object):
         self.server_thread.start()
 
     def stop(self):
-        self.logger.debug('Stopping...')
+        self.logger.debug("Stopping...")
         if self.server:
             self.server.shutdown()
             self.server.server_close()
@@ -104,12 +120,13 @@ class POPListener(object):
     def acceptDiverterListenerCallbacks(self, diverterListenerCallbacks):
         self.server.diverterListenerCallbacks = diverterListenerCallbacks
 
+
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
 
         # Timeout connection to prevent hanging
-        self.request.settimeout(int(self.server.config.get('timeout', 10)))
+        self.request.settimeout(int(self.server.config.get("timeout", 10)))
 
         try:
 
@@ -127,62 +144,59 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
                         if line and len(line) > 0:
 
-                            if b' ' in line:
-                                cmd, params = line.split(b' ', 1)
+                            if b" " in line:
+                                cmd, params = line.split(b" ", 1)
                             else:
-                                cmd, params = line, b''
+                                cmd, params = line, b""
 
                             cmd = cmd.decode("utf-8").upper()
-                            handler = getattr(self, 'pop_%s' % (cmd), self.pop_DEFAULT)
+                            handler = getattr(self, "pop_%s" % (cmd), self.pop_DEFAULT)
                             handler(cmd, params)
                             # Collect NBIs
-                            nbi = {
-                                'Command': cmd,
-                                'Params': params
-                                }
+                            nbi = {"Command": cmd, "Params": params}
                             self.collect_nbi(nbi)
 
         except socket.timeout:
-            self.server.logger.warning('Connection timeout')
+            self.server.logger.warning("Connection timeout")
 
         except socket.error as msg:
-            self.server.logger.error('Socket Error: %s', msg.strerror or msg)
+            self.server.logger.error("Socket Error: %s", msg.strerror or msg)
 
         except Exception as e:
-            self.server.logger.error('Error: %s', e)
+            self.server.logger.error("Error: %s", e)
 
     def pop_DEFAULT(self, cmd, params):
-        self.server.logger.info('Client issued an unknown command %s %s', cmd, params)
+        self.server.logger.info("Client issued an unknown command %s %s", cmd, params)
         self.request.sendall(b"-ERR Unknown command\r\n")
 
     def pop_APOP(self, cmd, params):
 
-        if b' ' in params:
-            mailbox_name, digest = params.split(b' ', 1)
-            self.server.logger.info('Client requests access to mailbox %s', mailbox_name)
+        if b" " in params:
+            mailbox_name, digest = params.split(b" ", 1)
+            self.server.logger.info("Client requests access to mailbox %s", mailbox_name)
 
             self.request.sendall(b"+OK %s's maildrop has 2 messages (320 octets)\r\n" % mailbox_name)
 
         else:
-            self.server.logger.info('Client sent invalid APOP command: APOP %s', params)
+            self.server.logger.info("Client sent invalid APOP command: APOP %s", params)
             self.request.sendall(b"-ERR\r\n")
 
     def pop_RPOP(self, cmd, params):
 
         mailbox_name = params
-        self.server.logger.info('Client requests access to mailbox %s', mailbox_name)
+        self.server.logger.info("Client requests access to mailbox %s", mailbox_name)
 
         self.request.sendall(b"+OK %s's maildrop has 2 messages (320 octets)\r\n" % mailbox_name)
 
     def pop_USER(self, cmd, params):
 
-        self.server.logger.info('Client user: %s', params)
+        self.server.logger.info("Client user: %s", params)
 
         self.request.sendall(b"+OK User accepted\r\n")
 
     def pop_PASS(self, cmd, params):
 
-        self.server.logger.info('Client password: %s', params)
+        self.server.logger.info("Client password: %s", params)
 
         self.request.sendall(b"+OK Pass accepted\r\n")
 
@@ -193,7 +207,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
     def pop_LIST(self, cmd, params):
 
         # List all messages
-        if params == b'':
+        if params == b"":
 
             self.request.sendall(b"+OK 2 messages (320 octets)\r\n")
             self.request.sendall(b"1 120\r\n")
@@ -205,10 +219,9 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
             self.request.sendall(b"+OK %d 200\r\n" % params)
             self.request.sendall(b".\r\n")
 
-
     def pop_RETR(self, cmd, params):
 
-        self.server.logger.info('Client requests message %s', params)
+        self.server.logger.info("Client requests message %s", params)
 
         self.request.sendall(b"+OK 120 octets\r\n")
         self.request.sendall(EMAIL + b"\r\n")
@@ -216,7 +229,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def pop_DELE(self, cmd, params):
 
-        self.server.logger.info('Client requests message %s to be deleted', params)
+        self.server.logger.info("Client requests message %s to be deleted", params)
 
         self.request.sendall(b"+OK message %s deleted\r\n", params)
 
@@ -234,7 +247,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def pop_UIDL(self, cmd, params):
 
-        if params == b'':
+        if params == b"":
             self.request.sendall(b"+OK\r\n")
             self.request.sendall(b"1 whqtswO00WBw418f9t5JxYwZa\r\n")
             self.request.sendall(b"2 QhdPYR:00WBw1Ph7x7a\r\n")
@@ -249,12 +262,14 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def collect_nbi(self, nbi):
         # Report diverter everytime we capture an NBI.
-        self.server.diverterListenerCallbacks.logNbi(self.client_address[1],
-                nbi, 'TCP', 'POP', self.server.config.get('usessl'))
+        self.server.diverterListenerCallbacks.logNbi(
+            self.client_address[1], nbi, "TCP", "POP", self.server.config.get("usessl")
+        )
 
 
 class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     pass
+
 
 ###############################################################################
 # Testing code
@@ -262,23 +277,26 @@ def test(config):
 
     import poplib
 
-    logger = logging.getLogger('POPListenerTest')
+    logger = logging.getLogger("POPListenerTest")
 
-    server = poplib.POP3_SSL('localhost', config.get('port', 110))
+    server = poplib.POP3_SSL("localhost", config.get("port", 110))
 
-    logger.info('Authenticating.')
-    server.user('username')
-    server.pass_('password')
+    logger.info("Authenticating.")
+    server.user("username")
+    server.pass_("password")
 
-    logger.info('Listing and retrieving messages.')
+    logger.info("Listing and retrieving messages.")
     print(server.list())
     print(server.retr(1))
     server.quit()
 
-def main():
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
 
-    config = {'port': '110', 'usessl': 'Yes', 'timeout': 30 }
+def main():
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
+
+    config = {"port": "110", "usessl": "Yes", "timeout": 30}
 
     listener = POPListener(config)
     listener.start()
@@ -297,5 +315,6 @@ def main():
     # Run tests
     test(config)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/ProxyListener.py
+++ b/fakenet/listeners/ProxyListener.py
@@ -23,81 +23,80 @@ BUF_SZ = 1024
 class ProxyListener(object):
 
     def __init__(
-            self,
-            config={},
-            name='ProxyListener',
-            logging_level=logging.DEBUG,
-            ):
+        self,
+        config={},
+        name="ProxyListener",
+        logging_level=logging.DEBUG,
+    ):
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging_level)
 
         self.config = config
         self.name = name
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
         self.udp_fwd_table = dict()
 
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
-    
+            self.logger.debug("  %10s: %s", key, value)
 
     def start(self):
 
-        proto = self.config.get('protocol').upper()
+        proto = self.config.get("protocol").upper()
         if proto != None:
 
-            if proto == 'TCP':
+            if proto == "TCP":
 
-                self.logger.debug('Starting TCP ...')                
+                self.logger.debug("Starting TCP ...")
                 config = {
-                    'cert_dir': self.config.get('cert_dir', 'configs/temp_certs'),
-                    'networkmode': self.config.get('networkmode', None),
-                    'static_ca': self.config.get('static_ca', 'No'),
-                    'ca_cert': self.config.get('ca_cert'),
-                    'ca_key': self.config.get('ca_key')
+                    "cert_dir": self.config.get("cert_dir", "configs/temp_certs"),
+                    "networkmode": self.config.get("networkmode", None),
+                    "static_ca": self.config.get("static_ca", "No"),
+                    "ca_cert": self.config.get("ca_cert"),
+                    "ca_key": self.config.get("ca_key"),
                 }
                 self.sslwrapper = SSLWrapper(config)
-                self.server = ThreadedTCPServer((self.local_ip,
-                    int(self.config.get('port'))), ThreadedTCPRequestHandler)
+                self.server = ThreadedTCPServer(
+                    (self.local_ip, int(self.config.get("port"))), ThreadedTCPRequestHandler
+                )
                 self.server.sslwrapper = self.sslwrapper
 
-            elif proto == 'UDP':
+            elif proto == "UDP":
 
-                self.logger.debug('Starting UDP ...')
+                self.logger.debug("Starting UDP ...")
 
-                self.server = ThreadedUDPServer((self.local_ip,
-                    int(self.config.get('port'))), ThreadedUDPRequestHandler)
+                self.server = ThreadedUDPServer(
+                    (self.local_ip, int(self.config.get("port"))), ThreadedUDPRequestHandler
+                )
                 self.server.fwd_table = self.udp_fwd_table
 
             else:
-                self.logger.error('Unknown protocol %s' % proto)
+                self.logger.error("Unknown protocol %s" % proto)
                 return
 
         else:
-            self.logger.error('Protocol is not defined')
+            self.logger.error("Protocol is not defined")
             return
 
         self.server.config = self.config
         self.server.logger = self.logger
         self.server.local_ip = self.local_ip
-        if self.local_ip == '0.0.0.0':
-            self.server.local_ip = 'localhost'
+        if self.local_ip == "0.0.0.0":
+            self.server.local_ip = "localhost"
         self.server.running_listeners = None
         self.server.diverter = None
-        self.server_thread = threading.Thread(
-                target=self.server.serve_forever)
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True
         self.server_thread.start()
         server_ip, server_port = self.server.server_address
-        self.logger.debug("%s Server(%s:%d) thread: %s" % (proto, server_ip,
-            server_port, self.server_thread.name))
+        self.logger.debug("%s Server(%s:%d) thread: %s" % (proto, server_ip, server_port, self.server_thread.name))
 
     def stop(self):
-        self.logger.debug('Stopping...')
+        self.logger.debug("Stopping...")
         if self.server:
             self.server.shutdown()
             self.server.server_close()
@@ -111,8 +110,8 @@ class ProxyListener(object):
     def acceptDiverterListenerCallbacks(self, diverterListenerCallbacks):
         self.server.diverterListenerCallbacks = diverterListenerCallbacks
 
-class ThreadedTCPClientSocket(threading.Thread):
 
+class ThreadedTCPClientSocket(threading.Thread):
 
     def __init__(self, ip, port, listener_q, remote_q, config, log):
 
@@ -132,7 +131,7 @@ class ThreadedTCPClientSocket(threading.Thread):
             return new_sport
 
         except Exception as e:
-            self.logger.debug('Listener socket exception while attempting connection %s' % str(e))
+            self.logger.debug("Listener socket exception while attempting connection %s" % str(e))
 
         return None
 
@@ -140,8 +139,7 @@ class ThreadedTCPClientSocket(threading.Thread):
 
         try:
             while True:
-                readable, writable, exceptional = select.select([self.sock],
-                        [], [], .001)
+                readable, writable, exceptional = select.select([self.sock], [], [], 0.001)
                 if not self.remote_q.empty():
                     data = self.remote_q.get()
                     self.sock.send(data)
@@ -153,24 +151,25 @@ class ThreadedTCPClientSocket(threading.Thread):
                         self.sock.close()
                         sys.exit(1)
         except Exception as e:
-            self.logger.debug('Listener socket exception %s' % str(e))
+            self.logger.debug("Listener socket exception %s" % str(e))
+
 
 class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     daemon_threads = True
 
+
 class ThreadedUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
     daemon_threads = True
 
-def get_top_listener(config, data, listeners, diverter, orig_src_ip,
-        orig_src_port, proto):
-    
+
+def get_top_listener(config, data, listeners, diverter, orig_src_ip, orig_src_port, proto):
 
     top_listener = None
     top_confidence = 0
     dport = diverter.getOriginalDestPort(orig_src_ip, orig_src_port, proto)
 
     for listener in listeners:
-  
+
         try:
             confidence = listener.taste(data, dport)
             if confidence > top_confidence:
@@ -179,8 +178,9 @@ def get_top_listener(config, data, listeners, diverter, orig_src_ip,
         except:
             # Exception occurs if taste() is not implemented for this listener
             pass
-    
+
     return top_listener
+
 
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
@@ -196,49 +196,60 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         try:
             data = remote_sock.recv(BUF_SZ, socket.MSG_PEEK)
 
-            self.server.logger.debug('Received %d bytes.', len(data))
-            self.server.logger.debug('%s', '-'*80,)
+            self.server.logger.debug("Received %d bytes.", len(data))
+            self.server.logger.debug(
+                "%s",
+                "-" * 80,
+            )
             for line in hexdump_table(data):
                 self.server.logger.debug(line)
-            self.server.logger.debug('%s', '-'*80,)
+            self.server.logger.debug(
+                "%s",
+                "-" * 80,
+            )
 
         except Exception as e:
-            self.server.logger.warning('recv() error: %s' % str(e))
-        
+            self.server.logger.warning("recv() error: %s" % str(e))
+
         # Is the pkt ssl encrypted?
         # Using a str here instead of bool to match the format returned by
         # configs of other listeners
-        is_ssl_encrypted = 'No'
+        is_ssl_encrypted = "No"
 
         if data:
             if ssl_detector.looks_like_ssl(data):
-                is_ssl_encrypted = 'Yes'
-                self.server.logger.debug('SSL detected')
+                is_ssl_encrypted = "Yes"
+                self.server.logger.debug("SSL detected")
                 ssl_remote_sock = self.server.sslwrapper.wrap_socket(remote_sock)
                 data = ssl_remote_sock.recv(BUF_SZ)
 
             else:
                 ssl_remote_sock = None
-            
+
             orig_src_ip = self.client_address[0]
             orig_src_port = self.client_address[1]
-            
-            top_listener = get_top_listener(self.server.config, data,
-                    self.server.listeners, self.server.diverter,
-                    orig_src_ip, orig_src_port, 'TCP')
+
+            top_listener = get_top_listener(
+                self.server.config, data, self.server.listeners, self.server.diverter, orig_src_ip, orig_src_port, "TCP"
+            )
 
             if top_listener:
-                self.server.logger.debug('Likely listener: %s' %
-                                         top_listener.name)
-                listener_sock = ThreadedTCPClientSocket(self.server.local_ip,
-                        top_listener.port, listener_q, remote_q,
-                        self.server.config, self.server.logger)
+                self.server.logger.debug("Likely listener: %s" % top_listener.name)
+                listener_sock = ThreadedTCPClientSocket(
+                    self.server.local_ip,
+                    top_listener.port,
+                    listener_q,
+                    remote_q,
+                    self.server.config,
+                    self.server.logger,
+                )
 
                 # Get proxy initiated source port and report to diverter
                 new_sport = listener_sock.connect()
                 if new_sport:
-                    self.server.diverterListenerCallbacks.mapProxySportToOrigSport('TCP',
-                            orig_src_port, new_sport, is_ssl_encrypted)
+                    self.server.diverterListenerCallbacks.mapProxySportToOrigSport(
+                        "TCP", orig_src_port, new_sport, is_ssl_encrypted
+                    )
 
                 listener_sock.daemon = True
                 listener_sock.start()
@@ -249,10 +260,9 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                 if ssl_remote_sock:
                     ssl_remote_sock.setblocking(0)
                     remote_q.put(data)
-                
+
                 while True:
-                    readable, writable, exceptional = select.select(
-                            [remote_sock], [], [], .001)
+                    readable, writable, exceptional = select.select([remote_sock], [], [], 0.001)
                     if readable:
                         try:
                             if ssl_remote_sock:
@@ -262,11 +272,10 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                             if data:
                                 remote_q.put(data)
                             else:
-                                self.server.logger.debug(
-                                        'Closing remote socket connection')
+                                self.server.logger.debug("Closing remote socket connection")
                                 return
                         except Exception as e:
-                            self.server.logger.debug('Remote Connection terminated')
+                            self.server.logger.debug("Remote Connection terminated")
                             return
                     if not listener_q.empty():
                         data = listener_q.get()
@@ -275,30 +284,35 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                         else:
                             remote_sock.send(data)
 
-class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
 
+class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
         data = self.request[0]
         remote_sock = self.request[1]
 
-        self.server.logger.debug('Received UDP packet from %s.' %
-                self.client_address[0])
+        self.server.logger.debug("Received UDP packet from %s." % self.client_address[0])
 
         if data:
 
-            self.server.logger.debug('Received %d bytes.', len(data))
-            self.server.logger.debug('%s', '-'*80,)
+            self.server.logger.debug("Received %d bytes.", len(data))
+            self.server.logger.debug(
+                "%s",
+                "-" * 80,
+            )
             for line in hexdump_table(data):
                 self.server.logger.debug(line)
-            self.server.logger.debug('%s', '-'*80,)
+            self.server.logger.debug(
+                "%s",
+                "-" * 80,
+            )
 
             orig_src_ip = self.client_address[0]
             orig_src_port = self.client_address[1]
 
-            top_listener = get_top_listener(self.server.config, data,
-                    self.server.listeners, self.server.diverter,
-                    orig_src_ip, orig_src_port, 'UDP')
+            top_listener = get_top_listener(
+                self.server.config, data, self.server.listeners, self.server.diverter, orig_src_ip, orig_src_port, "UDP"
+            )
 
             if top_listener:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -308,54 +322,57 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
                 # Get proxy initiated source port and report to diverter
                 new_sport = sock.getsockname()[1]
                 if new_sport:
-                    self.server.diverterListenerCallbacks.mapProxySportToOrigSport('UDP',
-                            orig_src_port, new_sport, 'No')
+                    self.server.diverterListenerCallbacks.mapProxySportToOrigSport(
+                        "UDP", orig_src_port, new_sport, "No"
+                    )
 
                 sock.sendto(data, (self.server.local_ip, int(top_listener.port)))
                 reply = sock.recv(BUF_SZ)
-                self.server.logger.debug('Received %d bytes.', len(data))
+                self.server.logger.debug("Received %d bytes.", len(data))
                 sock.close()
                 remote_sock.sendto(reply, (orig_src_ip, int(orig_src_port)))
         else:
-            self.server.logger.debug('No packet data')
+            self.server.logger.debug("No packet data")
+
 
 def hexdump_table(data, length=16):
 
     hexdump_lines = []
     for i in range(0, len(data), 16):
-        chunk = data[i:i+16]
-        hex_line   = ' '.join(["%02X" % b for b in chunk ] )
-        ascii_line = ''.join([chr(b) if b > 31 and b < 127 else '.' for b in chunk ] )
-        hexdump_lines.append("%04X: %-*s %s" % (i, length*3, hex_line, ascii_line ))
+        chunk = data[i : i + 16]
+        hex_line = " ".join(["%02X" % b for b in chunk])
+        ascii_line = "".join([chr(b) if b > 31 and b < 127 else "." for b in chunk])
+        hexdump_lines.append("%04X: %-*s %s" % (i, length * 3, hex_line, ascii_line))
     return hexdump_lines
+
 
 def main():
 
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s',
-            datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
     global listeners
     listeners = load_plugins()
 
-    TCP_server = ThreadedTCPServer((sys.argv[1], int(sys.argv[2])),
-            ThreadedTCPRequestHandler)
+    TCP_server = ThreadedTCPServer((sys.argv[1], int(sys.argv[2])), ThreadedTCPRequestHandler)
     TCP_server_thread = threading.Thread(target=TCP_server.serve_forever)
     TCP_server_thread.daemon = True
     TCP_server_thread.start()
     tcp_server_ip, tcp_server_port = TCP_server.server_address
-    logger.debug("TCP Server(%s:%d) thread: %s" % (tcp_server_ip,
-        tcp_server_port, TCP_server_thread.name))
+    logger.debug("TCP Server(%s:%d) thread: %s" % (tcp_server_ip, tcp_server_port, TCP_server_thread.name))
 
     try:
         while True:
-            time.sleep(.001)
+            time.sleep(0.001)
     except Exception as e:
         logger.info(e)
         TCP_server.shutdown()
     finally:
-        logger.debug('Closing ProxyListener')
+        logger.debug("Closing ProxyListener")
         sys.exit(1)
-    logger.debug('Exiting')
+    logger.debug("Exiting")
     TCP_server.shutdown()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/RawListener.py
+++ b/fakenet/listeners/RawListener.py
@@ -17,7 +17,7 @@ import socket
 
 from . import *
 
-INDENT = '  '
+INDENT = "  "
 
 
 def qualify_file_path(filename, fallbackdir):
@@ -26,9 +26,10 @@ def qualify_file_path(filename, fallbackdir):
         if not os.path.exists(path):
             path = os.path.join(fallbackdir, filename)
         if not os.path.exists(path):
-            raise RuntimeError('Cannot find %s' % (filename))
+            raise RuntimeError("Cannot find %s" % (filename))
 
     return path
+
 
 def load_source(modname, filename):
     loader = importlib.machinery.SourceFileLoader(modname, filename)
@@ -47,10 +48,10 @@ class RawCustomResponse(object):
         self.static = None
         self.handler = None
 
-        spec_file = '%srawfile' % (proto.lower())
-        spec_str = '%sstaticstring' % (proto.lower())
-        spec_b64 = '%sstaticbase64' % (proto.lower())
-        spec_dyn = '%sdynamic' % (proto.lower())
+        spec_file = "%srawfile" % (proto.lower())
+        spec_str = "%sstaticstring" % (proto.lower())
+        spec_b64 = "%sstaticbase64" % (proto.lower())
+        spec_dyn = "%sdynamic" % (proto.lower())
 
         response_specs = {
             spec_file,
@@ -61,14 +62,15 @@ class RawCustomResponse(object):
 
         nr_responses = len(response_specs.intersection(conf))
         if nr_responses != 1:
-            raise ValueError('Custom %s config section %s has %d of %s' %
-                             (proto.upper(), name, nr_responses,
-                              '/'.join(response_specs)))
+            raise ValueError(
+                "Custom %s config section %s has %d of %s"
+                % (proto.upper(), name, nr_responses, "/".join(response_specs))
+            )
 
         self.static = conf.get(spec_str)
 
         if self.static is not None:
-            self.static = self.static.rstrip('\r\n').encode("utf-8")
+            self.static = self.static.rstrip("\r\n").encode("utf-8")
 
         if not self.static is not None:
             b64_text = conf.get(spec_b64)
@@ -79,15 +81,14 @@ class RawCustomResponse(object):
             file_path = conf.get(spec_file)
             if file_path:
                 raw_file = qualify_file_path(file_path, configroot)
-                self.static = open(raw_file, 'rb').read()
+                self.static = open(raw_file, "rb").read()
 
         pymodpath = qualify_file_path(conf.get(spec_dyn), configroot)
         if pymodpath:
-            pymod = load_source('cr_raw_' + self.name, pymodpath)
-            funcname = 'Handle%s' % (proto.capitalize())
+            pymod = load_source("cr_raw_" + self.name, pymodpath)
+            funcname = "Handle%s" % (proto.capitalize())
             if not hasattr(pymod, funcname):
-                raise ValueError('Loaded %s module %s has no function %s' %
-                                 (spec_dyn, conf.get(spec_dyn), funcname))
+                raise ValueError("Loaded %s module %s has no function %s" % (spec_dyn, conf.get(spec_dyn), funcname))
             self.handler = getattr(pymod, funcname)
 
     def respondUdp(self, sock, data, addr):
@@ -102,69 +103,72 @@ class RawListener(object):
     def taste(self, data, dport):
         return 1
 
-    def __init__(self, 
-            config, 
-            name='RawListener', 
-            logging_level=logging.INFO, 
-            ):
+    def __init__(
+        self,
+        config,
+        name="RawListener",
+        logging_level=logging.INFO,
+    ):
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging_level)
-            
+
         self.config = config
         self.name = name
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
-        self.port = self.config.get('port', 1337)
+        self.port = self.config.get("port", 1337)
 
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
+            self.logger.debug("  %10s: %s", key, value)
 
     def start(self):
 
         # Start listener
-        proto = self.config.get('protocol')
+        proto = self.config.get("protocol")
         if proto is not None:
-            if proto.lower() == 'tcp':
-                self.logger.debug('Starting TCP ...')
-                self.server = ThreadedTCPServer((self.local_ip, int(self.config['port'])), ThreadedTCPRequestHandler)
+            if proto.lower() == "tcp":
+                self.logger.debug("Starting TCP ...")
+                self.server = ThreadedTCPServer((self.local_ip, int(self.config["port"])), ThreadedTCPRequestHandler)
 
-            elif proto.lower() == 'udp':
-                self.logger.debug('Starting UDP ...')
-                self.server = ThreadedUDPServer((self.local_ip, int(self.config['port'])), ThreadedUDPRequestHandler)
+            elif proto.lower() == "udp":
+                self.logger.debug("Starting UDP ...")
+                self.server = ThreadedUDPServer((self.local_ip, int(self.config["port"])), ThreadedUDPRequestHandler)
 
             else:
-                self.logger.error('Unknown protocol %s', self.config['protocol'])
+                self.logger.error("Unknown protocol %s", self.config["protocol"])
                 return
         else:
-            self.logger.error('Protocol is not defined.')
+            self.logger.error("Protocol is not defined.")
             return
 
         self.server.logger = self.logger
         self.server.config = self.config
 
-        if self.config.get('usessl') == 'Yes':
-            self.logger.debug('Using SSL socket.')
+        if self.config.get("usessl") == "Yes":
+            self.logger.debug("Using SSL socket.")
 
-            keyfile_path = 'listeners/ssl_utils/privkey.pem'
+            keyfile_path = "listeners/ssl_utils/privkey.pem"
             keyfile_path = ListenerBase.abs_config_path(keyfile_path)
             if keyfile_path is None:
-                self.logger.error('Could not locate %s', keyfile_path)
+                self.logger.error("Could not locate %s", keyfile_path)
                 sys.exit(1)
 
-            certfile_path = 'listeners/ssl_utils/server.pem'
+            certfile_path = "listeners/ssl_utils/server.pem"
             certfile_path = ListenerBase.abs_config_path(certfile_path)
             if certfile_path is None:
-                self.logger.error('Could not locate %s', certfile_path)
+                self.logger.error("Could not locate %s", certfile_path)
                 sys.exit(1)
 
-            self.server.socket = ssl.wrap_socket(self.server.socket, keyfile=keyfile_path, certfile=certfile_path, server_side=True, ciphers='RSA')
+            self.server.socket = ssl.wrap_socket(
+                self.server.socket, keyfile=keyfile_path, certfile=certfile_path, server_side=True, ciphers="RSA"
+            )
 
         self.server.custom_response = None
-        custom = self.config.get('custom')
+        custom = self.config.get("custom")
 
         def checkSetting(d, name, value):
             if name not in d:
@@ -172,7 +176,7 @@ class RawListener(object):
             return d[name].lower() == value.lower()
 
         if custom:
-            configdir = self.config.get('configdir')
+            configdir = self.config.get("configdir")
             custom = qualify_file_path(custom, configdir)
             customconf = ConfigParser()
             customconf.read(custom)
@@ -180,28 +184,24 @@ class RawListener(object):
             for section in customconf.sections():
                 entries = dict(customconf.items(section))
 
-                if (('instancename' not in entries) and
-                        ('listenertype' not in entries)):
-                    msg = 'Custom Response lacks ListenerType or InstanceName'
+                if ("instancename" not in entries) and ("listenertype" not in entries):
+                    msg = "Custom Response lacks ListenerType or InstanceName"
                     raise RuntimeError(msg)
 
-                if (checkSetting(entries, 'instancename', self.name) or
-                        checkSetting(entries, 'listenertype', proto)):
+                if checkSetting(entries, "instancename", self.name) or checkSetting(entries, "listenertype", proto):
 
                     if self.server.custom_response:
-                        msg = ('Only one %s Custom Response can be configured '
-                               'at a time' % (proto))
+                        msg = "Only one %s Custom Response can be configured " "at a time" % (proto)
                         raise RuntimeError(msg)
 
-                    self.server.custom_response = (
-                        RawCustomResponse(proto, section, entries, configdir))
+                    self.server.custom_response = RawCustomResponse(proto, section, entries, configdir)
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True
         self.server_thread.start()
 
     def stop(self):
-        self.logger.debug('Stopping...')
+        self.logger.debug("Stopping...")
         if self.server:
             self.server.shutdown()
             self.server.server_close()
@@ -209,13 +209,14 @@ class RawListener(object):
     def acceptDiverterListenerCallbacks(self, diverterListenerCallbacks):
         self.server.diverterListenerCallbacks = diverterListenerCallbacks
 
-class SocketWithHexdumpRecv():
+
+class SocketWithHexdumpRecv:
     def __init__(self, s, logger):
         self.s = s
         self.logger = logger
 
     def __getattr__(self, item):
-        if 'recv' == item:
+        if "recv" == item:
             return self.recv
         else:
             return getattr(self.s, item)
@@ -235,6 +236,7 @@ class SocketWithHexdumpRecv():
             self.do_hexdump(data)
         return data
 
+
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
@@ -245,7 +247,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         self.request = SocketWithHexdumpRecv(self.request, self.server.logger)
 
         # Timeout connection to prevent hanging
-        self.request.settimeout(int(self.server.config.get('timeout', 5)))
+        self.request.settimeout(int(self.server.config.get("timeout", 5)))
 
         cr = self.server.custom_response
 
@@ -255,7 +257,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
             cr.handler(self.request)
         else:
             try:
-                    
+
                 while True:
                     data = self.request.recv(1024)
                     if not data:
@@ -263,10 +265,13 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
                     # Collect NBIs
                     hexdump_lines = hexdump_table(data)
-                    collect_nbi(self.client_address[1], hexdump_lines,
-                                self.server.config.get('protocol'),
-                                self.server.config.get('usessl'),
-                                self.server.diverterListenerCallbacks)
+                    collect_nbi(
+                        self.client_address[1],
+                        hexdump_lines,
+                        self.server.config.get("protocol"),
+                        self.server.config.get("usessl"),
+                        self.server.diverterListenerCallbacks,
+                    )
 
                     if cr and cr.static:
                         self.request.sendall(cr.static)
@@ -274,26 +279,30 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                         self.request.sendall(data)
 
             except socket.timeout:
-                self.server.logger.warning('Connection timeout')
+                self.server.logger.warning("Connection timeout")
 
             except socket.error as msg:
-                self.server.logger.error('Error: %s', msg.strerror or msg)
+                self.server.logger.error("Error: %s", msg.strerror or msg)
 
             except Exception as e:
-                self.server.logger.error('Error: %s', e)
+                self.server.logger.error("Error: %s", e)
+
 
 class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
-        (data,sock) = self.request
+        (data, sock) = self.request
 
         if data:
             # Collect NBIs
             hexdump_lines = hexdump_table(data)
-            collect_nbi(self.client_address[1], hexdump_lines,
-                        self.server.config.get('protocol'),
-                        self.server.config.get('usessl'),
-                        self.server.diverterListenerCallbacks)
+            collect_nbi(
+                self.client_address[1],
+                hexdump_lines,
+                self.server.config.get("protocol"),
+                self.server.config.get("usessl"),
+                self.server.diverterListenerCallbacks,
+            )
 
             for line in hexdump_lines:
                 self.server.logger.info(INDENT + line)
@@ -306,10 +315,11 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
                 sock.sendto(data, self.client_address)
 
             except socket.error as msg:
-                self.server.logger.error('Error: %s', msg.strerror or msg)
+                self.server.logger.error("Error: %s", msg.strerror or msg)
 
             except Exception as e:
-                self.server.logger.error('Error: %s', e)
+                self.server.logger.error("Error: %s", e)
+
 
 class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     # Avoid [Errno 98] Address already in use due to TIME_WAIT status on TCP
@@ -317,30 +327,33 @@ class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     # https://stackoverflow.com/questions/4465959/python-errno-98-address-already-in-use
     allow_reuse_address = True
 
+
 class ThreadedUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
     pass
+
 
 def hexdump_table(data, length=16):
 
     hexdump_lines = []
     for i in range(0, len(data), 16):
-        chunk = data[i:i+16]
-        hex_line   = ' '.join(["%02X" % b for b in chunk ] )
-        ascii_line = ''.join([chr(b) if b > 31 and b < 127 else '.' for b in chunk ] )
-        hexdump_lines.append("%04X: %-*s %s" % (i, length*3, hex_line, ascii_line ))
+        chunk = data[i : i + 16]
+        hex_line = " ".join(["%02X" % b for b in chunk])
+        ascii_line = "".join([chr(b) if b > 31 and b < 127 else "." for b in chunk])
+        hexdump_lines.append("%04X: %-*s %s" % (i, length * 3, hex_line, ascii_line))
     return hexdump_lines
 
-def collect_nbi(sport, hexdump_lines, proto, is_ssl_encrypted,
-        diverterCallbacks):
+
+def collect_nbi(sport, hexdump_lines, proto, is_ssl_encrypted, diverterCallbacks):
     nbi = {}
     # Show upto 16 lines of hex dump
-    nbi['Data Hexdump'] = hexdump_lines[:16]
+    nbi["Data Hexdump"] = hexdump_lines[:16]
 
     # Report diverter everytime we capture an NBI
     # Using an empty string for application_layer_protocol in Raw Listener so
     # that diverter can override the empty string with the
     # transport_layer_protocol
-    diverterCallbacks.logNbi(sport, nbi, proto, '', is_ssl_encrypted)
+    diverterCallbacks.logNbi(sport, nbi, proto, "", is_ssl_encrypted)
+
 
 ###############################################################################
 # Testing code
@@ -351,7 +364,7 @@ def test(config):
     print("\t[RawListener] Sending request:\n%s" % "HELO\n")
     try:
         # Connect to server and send data
-        sock.connect(('localhost', int(config.get('port', 23))))
+        sock.connect(("localhost", int(config.get("port", 23))))
         sock.sendall(b"HELO\n")
 
         # Receive data from the server and shut down
@@ -359,14 +372,16 @@ def test(config):
     finally:
         sock.close()
 
-def main():
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
 
-    config = {'port': '1337', 'usessl': 'No', 'protocol': 'tcp'}
+def main():
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
+
+    config = {"port": "1337", "usessl": "No", "protocol": "tcp"}
 
     listener = RawListener(config)
     listener.start()
-
 
     ###########################################################################
     # Run processing
@@ -380,9 +395,10 @@ def main():
 
     ###########################################################################
     # Run tests
-    #test(config)
+    # test(config)
 
     listener.stop()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/SMTPListener.py
+++ b/fakenet/listeners/SMTPListener.py
@@ -13,18 +13,37 @@ import socket
 
 from . import *
 
+
 class SMTPListener(object):
 
     def taste(self, data, dport):
 
-        # Once the TCP connection has been established, the server initiates 
+        # Once the TCP connection has been established, the server initiates
         # the conversation with '220' message. However, if the client connects
         # to a nonstandard port there is no way for the proxy to know that
         # SMTP is the protocol until the client sends a message.
-        commands = [b'HELO', b'EHLO', b'MAIL FROM', b'RCPT TO', b'TURN', b'ATRN',
-                b'SIZE', b'ETRN', b'PIPELINING', b'CHUNKING', b'DATA', b'DSN',
-                b'RSET', b'VRFY', b'HELP', b'QUIT', b'X-EXPS GSSAPI',
-                b'X-EXPS=LOGIN', b'X-EXCH50', b'X-LINK2STATE']
+        commands = [
+            b"HELO",
+            b"EHLO",
+            b"MAIL FROM",
+            b"RCPT TO",
+            b"TURN",
+            b"ATRN",
+            b"SIZE",
+            b"ETRN",
+            b"PIPELINING",
+            b"CHUNKING",
+            b"DATA",
+            b"DSN",
+            b"RSET",
+            b"VRFY",
+            b"HELP",
+            b"QUIT",
+            b"X-EXPS GSSAPI",
+            b"X-EXPS=LOGIN",
+            b"X-EXCH50",
+            b"X-LINK2STATE",
+        ]
         ports = [25, 587, 465]
         confidence = 1 if dport in ports else 0
 
@@ -36,48 +55,50 @@ class SMTPListener(object):
         return confidence
 
     def __init__(
-            self,
-            config,
-            name='SMTPListener',
-            logging_level=logging.INFO,
-            ):
+        self,
+        config,
+        name="SMTPListener",
+        logging_level=logging.INFO,
+    ):
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging_level)
 
         self.config = config
         self.name = name
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
-        self.name = 'SMTP'
-        self.port = self.config.get('port', 25)
+        self.name = "SMTP"
+        self.port = self.config.get("port", 25)
 
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
+            self.logger.debug("  %10s: %s", key, value)
 
     def start(self):
-        self.logger.debug('Starting...')
-        self.server = ThreadedTCPServer((self.local_ip, int(self.config['port'])), ThreadedTCPRequestHandler)
+        self.logger.debug("Starting...")
+        self.server = ThreadedTCPServer((self.local_ip, int(self.config["port"])), ThreadedTCPRequestHandler)
 
-        if self.config.get('usessl') == 'Yes':
-            self.logger.debug('Using SSL socket')
+        if self.config.get("usessl") == "Yes":
+            self.logger.debug("Using SSL socket")
 
-            keyfile_path = 'listeners/ssl_utils/privkey.pem'
+            keyfile_path = "listeners/ssl_utils/privkey.pem"
             keyfile_path = ListenerBase.abs_config_path(keyfile_path)
             if keyfile_path is None:
-                self.logger.error('Could not locate %s', keyfile_path)
+                self.logger.error("Could not locate %s", keyfile_path)
                 sys.exit(1)
 
-            certfile_path = 'listeners/ssl_utils/server.pem'
+            certfile_path = "listeners/ssl_utils/server.pem"
             certfile_path = ListenerBase.abs_config_path(certfile_path)
             if certfile_path is None:
-                self.logger.error('Could not locate %s', certfile_path)
+                self.logger.error("Could not locate %s", certfile_path)
                 sys.exit(1)
 
-            self.server.socket = ssl.wrap_socket(self.server.socket, keyfile='privkey.pem', certfile='server.pem', server_side=True, ciphers='RSA')
+            self.server.socket = ssl.wrap_socket(
+                self.server.socket, keyfile="privkey.pem", certfile="server.pem", server_side=True, ciphers="RSA"
+            )
 
         self.server.logger = self.logger
         self.server.config = self.config
@@ -87,7 +108,7 @@ class SMTPListener(object):
         self.server_thread.start()
 
     def stop(self):
-        self.logger.debug('Stopping...')
+        self.logger.debug("Stopping...")
         if self.server:
             self.server.shutdown()
             self.server.server_close()
@@ -95,16 +116,19 @@ class SMTPListener(object):
     def acceptDiverterListenerCallbacks(self, diverterListenerCallbacks):
         self.server.diverterListenerCallbacks = diverterListenerCallbacks
 
+
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
 
         # Timeout connection to prevent hanging
-        self.request.settimeout(int(self.server.config.get('timeout', 5)))
+        self.request.settimeout(int(self.server.config.get("timeout", 5)))
 
         try:
 
-            self.request.sendall(b"%s\r\n" % self.server.config.get('banner', "220 FakeNet SMTP Service Ready").encode())
+            self.request.sendall(
+                b"%s\r\n" % self.server.config.get("banner", "220 FakeNet SMTP Service Ready").encode()
+            )
             while True:
                 data = self.request.recv(4096)
                 for line in data.split(b"\n"):
@@ -113,16 +137,16 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                 command = data[:4].decode("utf-8").upper()
                 args = data[4:].decode("utf-8").strip()
 
-                if command == '':
+                if command == "":
                     break
 
-                elif command in ['HELO','EHLO']:
+                elif command in ["HELO", "EHLO"]:
                     self.request.sendall(b"250 evil.com\r\n")
 
-                elif command in ['MAIL', 'RCPT', 'NOOP', 'RSET']:
+                elif command in ["MAIL", "RCPT", "NOOP", "RSET"]:
                     self.request.sendall(b"250 OK\r\n")
 
-                elif command == 'QUIT':
+                elif command == "QUIT":
                     self.request.sendall(b"221 evil.com bye\r\n")
 
                 elif command == "DATA":
@@ -140,7 +164,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                         if b"\r\n.\r\n" in mail_data:
                             break
 
-                    self.server.logger.info('Received mail data.')
+                    self.server.logger.info("Received mail data.")
                     for line in mail_data.split(b"\n"):
                         self.server.logger.info(line)
 
@@ -149,41 +173,37 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                     # Collect NBIs
                     # Mail data can be long. Let's capture the first line of the
                     # data for NBI.
-                    nbi = {
-                        "Command": command,
-                        "Mail Data": mail_data.decode('utf-8').split("\n")[0]
-                        }
+                    nbi = {"Command": command, "Mail Data": mail_data.decode("utf-8").split("\n")[0]}
                     self.collect_nbi(nbi)
 
                 else:
                     self.request.sendall(b"503 Command not supported\r\n")
 
                 # Collect NBIs
-                if command != 'DATA':
-                    args = None if args == '' else args
-                    nbi = {
-                        "Command": command,
-                        "Args": args
-                        }
+                if command != "DATA":
+                    args = None if args == "" else args
+                    nbi = {"Command": command, "Args": args}
                     self.collect_nbi(nbi)
 
         except socket.timeout:
-            self.server.logger.warning('Connection timeout')
-            
+            self.server.logger.warning("Connection timeout")
+
         except socket.error as msg:
-            self.server.logger.error('Error: %s', msg.strerror or msg)
+            self.server.logger.error("Error: %s", msg.strerror or msg)
 
         except Exception as e:
-            self.server.logger.error('Error: %s', e)
+            self.server.logger.error("Error: %s", e)
 
     def collect_nbi(self, nbi):
         # Report diverter everytime we capture an NBI
-        self.server.diverterListenerCallbacks.logNbi(self.client_address[1],
-                                                     nbi,'TCP', 'SMTP', 
-                                                     self.server.config.get('usessl'))
+        self.server.diverterListenerCallbacks.logNbi(
+            self.client_address[1], nbi, "TCP", "SMTP", self.server.config.get("usessl")
+        )
+
 
 class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     pass
+
 
 ###############################################################################
 # Testing code
@@ -191,23 +211,26 @@ def test(config):
 
     import smtplib
 
-    logger = logging.getLogger('SMTPListenerTest')
+    logger = logging.getLogger("SMTPListenerTest")
 
-    server = smtplib.SMTP_SSL('localhost', config.get('port', 25))
+    server = smtplib.SMTP_SSL("localhost", config.get("port", 25))
 
     message = "From: test@test.com\r\nTo: test@test.com\r\n\r\nTest message\r\n"
 
-    logger.info('Testing email request.')
-    logger.info('-'*80)
+    logger.info("Testing email request.")
+    logger.info("-" * 80)
     server.set_debuglevel(1)
-    server.sendmail('test@test.com','test@test.com', message)
+    server.sendmail("test@test.com", "test@test.com", message)
     server.quit()
-    logger.info('-'*80)
+    logger.info("-" * 80)
+
 
 def main():
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
 
-    config = {'port': '25', 'usessl': 'Yes', 'timeout': 10 }
+    config = {"port": "25", "usessl": "Yes", "timeout": 10}
 
     listener = SMTPListener(config)
     listener.start()
@@ -226,5 +249,6 @@ def main():
     # Run tests
     test(config)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/TFTPListener.py
+++ b/fakenet/listeners/TFTPListener.py
@@ -15,45 +15,44 @@ import urllib.request, urllib.parse, urllib.error
 from . import *
 
 EXT_FILE_RESPONSE = {
-    '.html': 'FakeNet.html',
-    '.png' : 'FakeNet.png',
-    '.ico' : 'FakeNet.ico',
-    '.jpeg': 'FakeNet.jpg',
-    '.exe' : 'FakeNetMini.exe',
-    '.pdf' : 'FakeNet.pdf',
-    '.xml' : 'FakeNet.html',
-    '.txt' : 'FakeNet.txt',
+    ".html": "FakeNet.html",
+    ".png": "FakeNet.png",
+    ".ico": "FakeNet.ico",
+    ".jpeg": "FakeNet.jpg",
+    ".exe": "FakeNetMini.exe",
+    ".pdf": "FakeNet.pdf",
+    ".xml": "FakeNet.html",
+    ".txt": "FakeNet.txt",
 }
 
-OPCODE_RRQ   = b"\x00\x01"
-OPCODE_WRQ   = b"\x00\x02"
-OPCODE_DATA  = b"\x00\x03"
-OPCODE_ACK   = b"\x00\x04"
+OPCODE_RRQ = b"\x00\x01"
+OPCODE_WRQ = b"\x00\x02"
+OPCODE_DATA = b"\x00\x03"
+OPCODE_ACK = b"\x00\x04"
 OPCODE_ERROR = b"\x00\x05"
 
 BLOCKSIZE = 512
 
-class TFTPListener(object):
 
+class TFTPListener(object):
 
     def taste(self, data, dport):
 
         max_filename_size = 128
-        max_mode_size = len('netascii')
+        max_mode_size = len("netascii")
         max_rrq_wrq_len = max_filename_size + max_mode_size + 4
         min_rrq_wrq_len = 6
         min_data_size = 5
         max_data_size = BLOCKSIZE + 4
         ack_size = 4
-        min_error_size = 5 + 1 
+        min_error_size = 5 + 1
         max_error_msg_size = 128
         max_error_size = 5 + max_error_msg_size
 
         confidence = 1 if dport == 69 else 0
 
         stripped = data.lstrip()
-        if (stripped.startswith(OPCODE_RRQ) or 
-                stripped().startswith(OPCODE_WRQ)):
+        if stripped.startswith(OPCODE_RRQ) or stripped().startswith(OPCODE_WRQ):
             if len(data) >= min_rrq_wrq_len and len(data) <= max_rrq_wrq_len:
                 confidence += 2
         elif stripped.startswith(OPCODE_DATA):
@@ -68,37 +67,38 @@ class TFTPListener(object):
 
         return confidence
 
-    def __init__(self,
-            config,
-            name='TFTPListener',
-            logging_level=logging.INFO,
-            ):
+    def __init__(
+        self,
+        config,
+        name="TFTPListener",
+        logging_level=logging.INFO,
+    ):
 
         self.logger = logging.getLogger(name)
-        self.logger.setLevel(logging_level) 
+        self.logger.setLevel(logging_level)
         self.config = config
         self.name = name
-        self.local_ip = config.get('ipaddr')
+        self.local_ip = config.get("ipaddr")
         self.server = None
-        self.name = 'TFTP'
-        self.port = self.config.get('port', 69)
+        self.name = "TFTP"
+        self.port = self.config.get("port", 69)
 
-        self.logger.debug('Initialized with config:')
+        self.logger.debug("Initialized with config:")
         for key, value in config.items():
-            self.logger.debug('  %10s: %s', key, value)
+            self.logger.debug("  %10s: %s", key, value)
 
-        path = self.config.get('tftproot', 'defaultFiles')
+        path = self.config.get("tftproot", "defaultFiles")
         self.tftproot_path = ListenerBase.abs_config_path(path)
         if self.tftproot_path is None:
-            self.logger.error('Could not locate tftproot directory: %s', path)
+            self.logger.error("Could not locate tftproot directory: %s", path)
             sys.exit(1)
 
-        self.tftp_file_prefix = self.config.get('tftpfileprefix', 'tftp')
+        self.tftp_file_prefix = self.config.get("tftpfileprefix", "tftp")
 
     def start(self):
-        self.logger.debug('Starting...')
+        self.logger.debug("Starting...")
         # Start listener
-        self.server = ThreadedUDPServer((self.local_ip, int(self.config['port'])), ThreadedUDPRequestHandler)
+        self.server = ThreadedUDPServer((self.local_ip, int(self.config["port"])), ThreadedUDPRequestHandler)
 
         self.server.logger = self.logger
         self.server.config = self.config
@@ -110,7 +110,7 @@ class TFTPListener(object):
         self.server_thread.start()
 
     def stop(self):
-        self.logger.debug('Stopping...')
+        self.logger.debug("Stopping...")
         if self.server:
             self.server.shutdown()
             self.server.server_close()
@@ -118,12 +118,13 @@ class TFTPListener(object):
     def acceptDiverterListenerCallbacks(self, diverterListenerCallbacks):
         self.server.diverterListenerCallbacks = diverterListenerCallbacks
 
+
 class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
 
         try:
-            (data,socket) = self.request
+            (data, socket) = self.request
 
             if not data:
                 return
@@ -132,40 +133,37 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
 
             if opcode == OPCODE_RRQ:
                 filename, mode = self.parse_rrq_wrq_packet(data)
-                self.server.logger.info('Received request to download %s', filename)
-                self.handle_rrq(socket, filename.decode('utf-8'))
+                self.server.logger.info("Received request to download %s", filename)
+                self.handle_rrq(socket, filename.decode("utf-8"))
 
                 # Collect NBIs
                 indicator_filename = filename
                 if isinstance(filename, bytes):
-                    indicator_filename = filename.decode('utf-8')
+                    indicator_filename = filename.decode("utf-8")
                 nbi = {"Command": "RRQ", "Filename": indicator_filename}
                 self.collect_nbi(nbi)
 
             elif opcode == OPCODE_WRQ:
 
                 filename, mode = self.parse_rrq_wrq_packet(data)
-                self.server.logger.info('Received request to upload %s', filename)
+                self.server.logger.info("Received request to upload %s", filename)
 
                 self.handle_wrq(socket, filename)
 
                 # Collect NBIs
                 indicator_filename = filename
                 if isinstance(filename, bytes):
-                    indicator_filename = filename.decode('utf-8')
+                    indicator_filename = filename.decode("utf-8")
                 nbi = {"Command": "WRQ", "Filename": indicator_filename}
                 self.collect_nbi(nbi)
 
             elif opcode == OPCODE_ACK:
 
-                block_num = struct.unpack('!H', data[2:4])[0]
-                self.server.logger.debug('Received ACK for block %d', block_num)
+                block_num = struct.unpack("!H", data[2:4])[0]
+                self.server.logger.debug("Received ACK for block %d", block_num)
 
                 # Collect NBIs
-                nbi = {
-                    "Command": "ACK",
-                    "Block Number": block_num
-                    }
+                nbi = {"Command": "ACK", "Block Number": block_num}
                 self.collect_nbi(nbi)
 
             elif opcode == OPCODE_DATA:
@@ -174,78 +172,67 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
 
             elif opcode == OPCODE_ERROR:
 
-                    error_num = struct.unpack('!H', data[2:4])[0]
-                    error_msg = data.decode('utf-8')[4:]
+                error_num = struct.unpack("!H", data[2:4])[0]
+                error_msg = data.decode("utf-8")[4:]
 
-                    self.server.logger.info('Received error message %d:%s', error_num, error_msg)
+                self.server.logger.info("Received error message %d:%s", error_num, error_msg)
 
-                    # Collect NBIs
-                    nbi = {
-                        "Command": "ERROR",
-                        "Error Number": error_num,
-                        "Error Message": error_msg
-                        }
-                    self.collect_nbi(nbi)
+                # Collect NBIs
+                nbi = {"Command": "ERROR", "Error Number": error_num, "Error Message": error_msg}
+                self.collect_nbi(nbi)
 
             else:
 
-                unknown_opcode = struct.unpack('!H', data[:2])[0]
-                self.server.logger.error('Unknown opcode: %d', unknown_opcode)
+                unknown_opcode = struct.unpack("!H", data[:2])[0]
+                self.server.logger.error("Unknown opcode: %d", unknown_opcode)
 
                 # Collect NBIs
-                nbi = {
-                    "Command": "Unknown command",
-                    "Opcode": str(unknown_opcode),
-                    "Data": data.decode("utf-8")[4:]
-                    }
+                nbi = {"Command": "Unknown command", "Opcode": str(unknown_opcode), "Data": data.decode("utf-8")[4:]}
                 self.collect_nbi(nbi)
 
         except Exception as e:
-            self.server.logger.error('Error: %s', e)
+            self.server.logger.error("Error: %s", e)
             raise e
 
     def handle_data(self, socket, data):
 
-            block_num = struct.unpack('!H', data[2:4])[0]
+        block_num = struct.unpack("!H", data[2:4])[0]
 
-            if hasattr(self.server, 'filename_path') and self.server.filename_path:
+        if hasattr(self.server, "filename_path") and self.server.filename_path:
 
-                safe_file = self.server.tftp_file_prefix + "_" + urllib.parse.quote(self.server.filename_path, '')
-                output_file = ListenerBase.safe_join(os.getcwd(),
-                                                          safe_file)
-                f = open(output_file, 'ab')
-                f.write(data[4:])
-                f.close()
+            safe_file = self.server.tftp_file_prefix + "_" + urllib.parse.quote(self.server.filename_path, "")
+            output_file = ListenerBase.safe_join(os.getcwd(), safe_file)
+            f = open(output_file, "ab")
+            f.write(data[4:])
+            f.close()
 
-                # Collect NBIs
-                indicator_data = data
-                indicator_filename = self.server.filename_path
-                if isinstance(data, bytes):
-                    indicator_data = data.decode('utf-8')
-                if isinstance(self.server.filename_path, bytes):
-                    indicator_filename = self.server.filename_path.decode('utf-8')
+            # Collect NBIs
+            indicator_data = data
+            indicator_filename = self.server.filename_path
+            if isinstance(data, bytes):
+                indicator_data = data.decode("utf-8")
+            if isinstance(self.server.filename_path, bytes):
+                indicator_filename = self.server.filename_path.decode("utf-8")
 
-                # Send ACK packet for the given block number
-                ack_packet = OPCODE_ACK + data[2:4]
-                socket.sendto(ack_packet, self.client_address)
+            # Send ACK packet for the given block number
+            ack_packet = OPCODE_ACK + data[2:4]
+            socket.sendto(ack_packet, self.client_address)
 
-            else:
-                # Collect NBIs
-                indicator_data = data
-                indicator_filename = None
-                if isinstance(data, bytes):
-                    indicator_data = data.decode('utf-8')
+        else:
+            # Collect NBIs
+            indicator_data = data
+            indicator_filename = None
+            if isinstance(data, bytes):
+                indicator_data = data.decode("utf-8")
 
-                self.server.logger.error('Received DATA packet but don\'t know where to store it.')
+            self.server.logger.error("Received DATA packet but don't know where to store it.")
 
-            nbi = {"Command": "DATA", "Data": indicator_data[4:], "Filename":
-                    indicator_filename}
-            self.collect_nbi(nbi)
+        nbi = {"Command": "DATA", "Data": indicator_data[4:], "Filename": indicator_filename}
+        self.collect_nbi(nbi)
 
     def handle_rrq(self, socket, filename):
 
-        filename_path = ListenerBase.safe_join(self.server.tftproot_path,
-                                                    filename)
+        filename_path = ListenerBase.safe_join(self.server.tftproot_path, filename)
 
         # If virtual filename does not exist return a default file based on extention
         if not os.path.isfile(filename_path):
@@ -253,13 +240,13 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
             file_basename, file_extension = os.path.splitext(filename)
 
             # Calculate absolute path to a fake file
-            filename_path = ListenerBase.safe_join(self.server.tftproot_path,
-                                                        EXT_FILE_RESPONSE.get(file_extension.lower(), 'FakeNetMini.exe'))
+            filename_path = ListenerBase.safe_join(
+                self.server.tftproot_path, EXT_FILE_RESPONSE.get(file_extension.lower(), "FakeNetMini.exe")
+            )
 
+        self.server.logger.debug("Sending file %s", filename_path)
 
-        self.server.logger.debug('Sending file %s', filename_path)
-
-        f = open(filename_path, 'rb')
+        f = open(filename_path, "rb")
 
         i = 1
 
@@ -271,7 +258,7 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
             if not data_block or len(data_block) == 0:
                 break
 
-            data_packet = OPCODE_DATA + struct.pack('!H', i) + data_block
+            data_packet = OPCODE_DATA + struct.pack("!H", i) + data_block
             socket.sendto(data_packet, self.client_address)
 
             i += 1
@@ -286,7 +273,6 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
         ack_packet = OPCODE_ACK + b"\x00\x00"
         socket.sendto(ack_packet, self.client_address)
 
-
     def parse_rrq_wrq_packet(self, data):
 
         filename, mode, _ = data[2:].split(b"\x00", 2)
@@ -294,16 +280,18 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
 
     def collect_nbi(self, nbi):
         # Report diverter everytime we capture an NBI
-        self.server.diverterListenerCallbacks.logNbi(self.client_address[1],
-                nbi, 'UDP', 'TFTP', 'No')
+        self.server.diverterListenerCallbacks.logNbi(self.client_address[1], nbi, "UDP", "TFTP", "No")
+
 
 class ThreadedUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
     pass
+
 
 ###############################################################################
 # Testing code
 def test(config):
     pass
+
 
 def main():
     """
@@ -312,9 +300,11 @@ def main():
        python2 -m fakenet.listeners.TFTPListener
 
     """
-    logging.basicConfig(format='%(asctime)s [%(name)15s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.DEBUG)
+    logging.basicConfig(
+        format="%(asctime)s [%(name)15s] %(message)s", datefmt="%m/%d/%y %I:%M:%S %p", level=logging.DEBUG
+    )
 
-    config = {'port': '69', 'protocol': 'udp', 'tftproot': 'defaultFiles'}
+    config = {"port": "69", "protocol": "udp", "tftproot": "defaultFiles"}
 
     listener = TFTPListener(config)
     listener.start()
@@ -331,9 +321,10 @@ def main():
 
     ###########################################################################
     # Run tests
-    #test(config)
+    # test(config)
 
     listener.stop()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/fakenet/listeners/__init__.py
+++ b/fakenet/listeners/__init__.py
@@ -13,4 +13,15 @@ from . import ProxyListener
 
 import os
 
-__all__ = ['ListenerBase', 'RawListener', 'HTTPListener', 'DNSListener', 'SMTPListener', 'FTPListener', 'IRCListener', 'TFTPListener', 'POPListener', 'ProxyListener']
+__all__ = [
+    "ListenerBase",
+    "RawListener",
+    "HTTPListener",
+    "DNSListener",
+    "SMTPListener",
+    "FTPListener",
+    "IRCListener",
+    "TFTPListener",
+    "POPListener",
+    "ProxyListener",
+]

--- a/fakenet/listeners/ssl_utils/ssl_detector.py
+++ b/fakenet/listeners/ssl_utils/ssl_detector.py
@@ -2,37 +2,27 @@
 
 import logging
 
+
 def looks_like_ssl(data):
 
     size = len(data)
 
-    valid_versions = { 
-    'SSLV3'   : 0x300,
-    'TLSV1'   : 0x301,
-    'TLSV1_1' : 0x302,
-    'TLSv1_2' : 0x303
-    }
+    valid_versions = {"SSLV3": 0x300, "TLSV1": 0x301, "TLSV1_1": 0x302, "TLSv1_2": 0x303}
 
-    content_types = {
-    'ChangeCipherSpec'  : 0x14,
-    'Alert'             : 0x15,
-    'Handshake'         : 0x16,
-    'Application'       : 0x17,
-    'Heartbeat'         : 0x18
-    }
+    content_types = {"ChangeCipherSpec": 0x14, "Alert": 0x15, "Handshake": 0x16, "Application": 0x17, "Heartbeat": 0x18}
 
     handshake_message_types = {
-    'HelloRequest'      : 0x00,
-    'ClientHello'       : 0x01,
-    'ServerHello'       : 0x02,
-    'NewSessionTicket'  : 0x04,
-    'Certificate'       : 0x0B,
-    'ServerKeyExchange' : 0x0C,
-    'CertificateRequest': 0x0D,
-    'ServerHelloDone'   : 0x0E,
-    'CertificateVerify' : 0x0F,
-    'ClientKeyExchange' : 0x10,
-    'Finished'          : 0x14
+        "HelloRequest": 0x00,
+        "ClientHello": 0x01,
+        "ServerHello": 0x02,
+        "NewSessionTicket": 0x04,
+        "Certificate": 0x0B,
+        "ServerKeyExchange": 0x0C,
+        "CertificateRequest": 0x0D,
+        "ServerHelloDone": 0x0E,
+        "CertificateVerify": 0x0F,
+        "ClientKeyExchange": 0x10,
+        "Finished": 0x14,
     }
 
     if size < 10:
@@ -41,18 +31,17 @@ def looks_like_ssl(data):
     # check for sslv2 which is deprecated but malware may use it anyway
     if data[0] == 0x80:
         if data[2] in handshake_message_types:
-            self.logger.info('SSLv2 detected')
+            self.logger.info("SSLv2 detected")
             return True
         return False
 
     elif data[0] not in list(content_types.values()):
         return False
 
-    elif data[0] == content_types['Handshake']:
+    elif data[0] == content_types["Handshake"]:
         return data[5] in list(handshake_message_types.values())
 
     ssl_version = data[1] << 8 | data[2]
     if ssl_version not in list(valid_versions.values()):
         return False
     return True
-

--- a/setup.py
+++ b/setup.py
@@ -18,27 +18,39 @@ requirements = [
     "jinja2",
 ]
 
-if platform.system() == 'Windows':
+if platform.system() == "Windows":
     requirements.append("pydivert")
-elif platform.system().lower().startswith('linux'):
+elif platform.system().lower().startswith("linux"):
     requirements.append("netfilterqueue")
 
 setup(
-    name='FakeNet NG',
-    version='3.5',
+    name="FakeNet NG",
+    version="3.5",
     description="",
     long_description="",
     author="Mandiant FLARE Team with credit to Peter Kacherginsky as the original developer",
-    author_email='FakeNet@mandiant.com',
-    url='https://www.github.com/mandiant/flare-fakenet-ng',
+    author_email="FakeNet@mandiant.com",
+    url="https://www.github.com/mandiant/flare-fakenet-ng",
     packages=[
-        'fakenet',
+        "fakenet",
     ],
-    package_dir={'fakenet': 'fakenet'},
-    package_data={'fakenet': ['*.pem','diverters/*.py', 'listeners/*.py',
-        'listeners/ssl_utils/*.py', 'listeners/ssl_utils/*.pem', 'configs/*.ini',
-        'configs/html_report_template.html', 'defaultFiles/*', 'lib/64/*', 'lib/32/*',
-        'configs/*.crt', 'configs/*.key']},
+    package_dir={"fakenet": "fakenet"},
+    package_data={
+        "fakenet": [
+            "*.pem",
+            "diverters/*.py",
+            "listeners/*.py",
+            "listeners/ssl_utils/*.py",
+            "listeners/ssl_utils/*.pem",
+            "configs/*.ini",
+            "configs/html_report_template.html",
+            "defaultFiles/*",
+            "lib/64/*",
+            "lib/32/*",
+            "configs/*.crt",
+            "configs/*.key",
+        ]
+    },
     entry_points={
         "console_scripts": [
             "fakenet=fakenet.fakenet:main",
@@ -47,11 +59,11 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     zip_safe=False,
-    keywords='fakenet-ng',
+    keywords="fakenet-ng",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
     ],
 )

--- a/test/CustomProviderExample.py
+++ b/test/CustomProviderExample.py
@@ -2,6 +2,7 @@
 
 import socket
 
+
 # To read about customizing HTTP responses, see docs/CustomResponse.md
 def HandleRequest(req, method, post_data=None):
     """Sample dynamic HTTP response handler.
@@ -16,21 +17,21 @@ def HandleRequest(req, method, post_data=None):
         The HTTP post data received by calling `rfile.read()` against the
         BaseHTTPRequestHandler that received the request.
     """
-    response = b'Ahoy\r\n'
+    response = b"Ahoy\r\n"
 
-    if method == 'GET':
+    if method == "GET":
         req.send_response(200)
-        req.send_header('Content-Length', len(response))
+        req.send_header("Content-Length", len(response))
         req.end_headers()
         req.wfile.write(response)
 
-    elif method == 'POST':
+    elif method == "POST":
         req.send_response(200)
-        req.send_header('Content-Length', len(response))
+        req.send_header("Content-Length", len(response))
         req.end_headers()
         req.wfile.write(response)
 
-    elif method == 'HEAD':
+    elif method == "HEAD":
         req.send_response(200)
         req.end_headers()
 
@@ -53,7 +54,7 @@ def HandleTcp(sock):
         if not data:
             break
 
-        resp = b''.join([chr(c+1).encode() for c in data])
+        resp = b"".join([chr(c + 1).encode() for c in data])
         sock.sendall(resp)
 
 
@@ -70,5 +71,5 @@ def HandleUdp(sock, data, addr):
         The host and port of the remote peer
     """
     if data:
-        resp = b''.join([chr(c+1).encode() for c in data])
+        resp = b"".join([chr(c + 1).encode() for c in data])
         sock.sendto(resp, addr)

--- a/test/test.py
+++ b/test/test.py
@@ -27,8 +27,9 @@ from collections import OrderedDict
 from icmplib import ping
 from requests.adapters import HTTPAdapter
 
-logger = logging.getLogger('FakeNetTests')
-logging.basicConfig(format='%(message)s', level=logging.INFO)
+logger = logging.getLogger("FakeNetTests")
+logging.basicConfig(format="%(message)s", level=logging.INFO)
+
 
 def is_admin():
     result = False
@@ -37,6 +38,7 @@ def is_admin():
     except AttributeError:
         result = ctypes.windll.shell32.IsUserAnAdmin() != 0
     return result
+
 
 def execute_detached(execute_cmd, winders=False):
     DETACHED_PROCESS = 0x00000008
@@ -49,24 +51,21 @@ def execute_detached(execute_cmd, winders=False):
         # terminating child processes
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-
     preexec = None if winders else ign_sigint
 
     try:
-        pid = subprocess.Popen(execute_cmd, creationflags=cflags,
-                               shell=shl,
-                               close_fds = cfds,
-                               preexec_fn = preexec).pid
+        pid = subprocess.Popen(execute_cmd, creationflags=cflags, shell=shl, close_fds=cfds, preexec_fn=preexec).pid
     except Exception as e:
-        logger.info('Error: Failed to execute command: %s', execute_cmd)
-        logger.info('       %s', e)
+        logger.info("Error: Failed to execute command: %s", execute_cmd)
+        logger.info("       %s", e)
         return None
     else:
         return pid
 
+
 def get_ips(ipvers):
     """Return IP addresses bound to local interfaces including loopbacks.
-    
+
     Parameters
     ----------
     ipvers : list
@@ -82,7 +81,7 @@ def get_ips(ipvers):
         elif ver == 6:
             specs.append(netifaces.AF_INET6)
         else:
-            raise ValueError('get_ips only supports IP versions 4 and 6')
+            raise ValueError("get_ips only supports IP versions 4 and 6")
 
     for iface in netifaces.interfaces():
         for spec in specs:
@@ -92,44 +91,44 @@ def get_ips(ipvers):
             # addresses dictionary.
             if spec in addrs:
                 for link in addrs[spec]:
-                    if 'addr' in link:
-                        results.append(link['addr'])
+                    if "addr" in link:
+                        results.append(link["addr"])
 
     return results
+
 
 def get_external_ip():
     addrs = get_ips([4])
     for addr in addrs:
-        if not addr.startswith('127.'):
+        if not addr.startswith("127."):
             return addr
+
 
 class IrcTester(object):
     def __init__(self, hostname, port=6667):
         self.hostname = hostname
         self.port = port
 
-        self.nick = 'dr_evil'
-        self.join_chan = '#whatevs'
-        self.clouseau = 'inspector_clouseau'
+        self.nick = "dr_evil"
+        self.join_chan = "#whatevs"
+        self.clouseau = "inspector_clouseau"
         self.safehouse = "I'm looking for a safe house."
-        self.pub_chan = '#evil_bartenders'
-        self.black_market = 'Black Market'
+        self.pub_chan = "#evil_bartenders"
+        self.black_market = "Black Market"
 
     def _irc_evt_handler(self, srv, evt):
         """Check for each case and set the corresponding success flag."""
-        if evt.type == 'join':
+        if evt.type == "join":
             if evt.target.startswith(self.join_chan):
                 self.join_ok = True
-        elif evt.type == 'welcome':
-            if evt.arguments[0].startswith('Welcome to IRC'):
+        elif evt.type == "welcome":
+            if evt.arguments[0].startswith("Welcome to IRC"):
                 self.welcome_ok = True
-        elif evt.type == 'privmsg':
-            if (evt.arguments[0].startswith(self.safehouse) and
-                evt.source.startswith(self.clouseau)):
+        elif evt.type == "privmsg":
+            if evt.arguments[0].startswith(self.safehouse) and evt.source.startswith(self.clouseau):
                 self.privmsg_ok = True
-        elif evt.type == 'pubmsg':
-            if (evt.arguments[0].startswith(self.black_market) and
-                evt.target == self.pub_chan):
+        elif evt.type == "pubmsg":
+            if evt.arguments[0].startswith(self.black_market) and evt.target == self.pub_chan:
                 self.pubmsg_ok = True
 
     def _irc_script(self, srv):
@@ -141,10 +140,10 @@ class IrcTester(object):
         self.pubmsg_ok = False
 
         # This handler should set the success flags in success cases
-        srv.add_global_handler('join', self._irc_evt_handler)
-        srv.add_global_handler('welcome', self._irc_evt_handler)
-        srv.add_global_handler('privmsg', self._irc_evt_handler)
-        srv.add_global_handler('pubmsg', self._irc_evt_handler)
+        srv.add_global_handler("join", self._irc_evt_handler)
+        srv.add_global_handler("welcome", self._irc_evt_handler)
+        srv.add_global_handler("privmsg", self._irc_evt_handler)
+        srv.add_global_handler("pubmsg", self._irc_evt_handler)
 
         # Issue all commands, indirectly invoking the event handler for each
         # flag
@@ -162,23 +161,18 @@ class IrcTester(object):
         srv.process_data()
 
         if not self.welcome_ok:
-            raise FakeNetTestException('Welcome test failed')
+            raise FakeNetTestException("Welcome test failed")
 
         if not self.join_ok:
-            raise FakeNetTestException('Join test failed')
+            raise FakeNetTestException("Join test failed")
 
         if not self.privmsg_ok:
-            raise FakeNetTestException('privmsg test failed')
+            raise FakeNetTestException("privmsg test failed")
 
         if not self.pubmsg_ok:
-            raise FakeNetTestException('pubmsg test failed')
+            raise FakeNetTestException("pubmsg test failed")
 
-        return all([
-            self.welcome_ok,
-            self.join_ok,
-            self.privmsg_ok,
-            self.pubmsg_ok
-           ])
+        return all([self.welcome_ok, self.join_ok, self.privmsg_ok, self.pubmsg_ok])
 
     def _run_irc_script(self, nm, callback):
         """Connect to server and give control to callback."""
@@ -190,13 +184,16 @@ class IrcTester(object):
         return retval
 
     def test_irc(self):
-        return self._run_irc_script('testnm', self._irc_script)
+        return self._run_irc_script("testnm", self._irc_script)
+
 
 class FakeNetTestException(Exception):
     """A recognizable exception type indicating a known failure state based on
     test criteria. HTTP test uses this, others may in the future, too.
     """
+
     pass
+
 
 class FakeNetTester(object):
     """Controller for FakeNet-NG that runs test cases"""
@@ -206,8 +203,8 @@ class FakeNetTester(object):
         self.pid_fakenet = None
 
     def _setStopFlag(self):
-        with open(self.settings.stopflag, 'w') as f:
-            f.write('1')
+        with open(self.settings.stopflag, "w") as f:
+            f.write("1")
 
     def _clearStopFlag(self):
         if os.path.exists(self.settings.stopflag):
@@ -265,7 +262,7 @@ class FakeNetTester(object):
 
     def stopFakenetAndWait(self, timeoutsec=None, kill=False):
         if not self.pid_fakenet:
-            raise RuntimeError('FakeNet-NG not running, nothing to stop')
+            raise RuntimeError("FakeNet-NG not running, nothing to stop")
 
         self._setStopFlag()
         stopped_responsive = self._waitFakenetStopped(timeoutsec)
@@ -282,8 +279,7 @@ class FakeNetTester(object):
 
     def executeFakenet(self):
         if self.pid_fakenet:
-            raise RuntimeError('FakeNet-NG already running, PID %d' %
-                               (self.pid_fakenet))
+            raise RuntimeError("FakeNet-NG already running, PID %d" % (self.pid_fakenet))
 
         os.chdir(self.settings.fndir)
 
@@ -292,25 +288,24 @@ class FakeNetTester(object):
             for i in range(1, max_del_attempts + 1):
                 try:
                     os.remove(self.settings.logpath)
-                except WindowsError: # i.e. log file locked by another process
-                    logger.warning('Failed to delete %s, attempt %d' %
-                                   (self.settings.logpath, i))
+                except WindowsError:  # i.e. log file locked by another process
+                    logger.warning("Failed to delete %s, attempt %d" % (self.settings.logpath, i))
                     if i == max_del_attempts:
-                        logger.error('Final attempt, re-raising exception')
+                        logger.error("Final attempt, re-raising exception")
                         raise
                     else:
-                        logger.warning('Retrying in %d seconds...' % (i))
+                        logger.warning("Retrying in %d seconds..." % (i))
                         time.sleep(i)
                 else:
                     break
 
         cmd = self.settings.genFakenetCmd()
-        logger.info('About to run %s' % (cmd))
+        logger.info("About to run %s" % (cmd))
         self.pid_fakenet = execute_detached(cmd, self.settings.windows)
         if self.pid_fakenet:
-            logger.info('FakeNet started with PID %s' % (str(self.pid_fakenet)))
+            logger.info("FakeNet started with PID %s" % (str(self.pid_fakenet)))
 
-        return (self.pid_fakenet is not None)
+        return self.pid_fakenet is not None
 
     def delConfig(self):
         if os.path.exists(self.settings.configpath):
@@ -323,19 +318,18 @@ class FakeNetTester(object):
         self.testWhitelistProcess(match_spec)
 
     def _printStatus(self, desc, passed):
-        status = 'Passed' if passed else 'FAILED'
-        punc = '[ + ]' if passed else '[!!!]'
-        logger.info('%s %s: %s' % (punc, status, desc))
+        status = "Passed" if passed else "FAILED"
+        punc = "[ + ]" if passed else "[!!!]"
+        logger.info("%s %s: %s" % (punc, status, desc))
 
     def _tryTest(self, desc, callback, args, expected):
         retval = None
         try:
             retval = callback(*args)
         except Exception as e:
-            logger.info('Test %s: Uncaught exception of type %s: %s' %
-                        (desc, str(type(e)), str(e)))
+            logger.info("Test %s: Uncaught exception of type %s: %s" % (desc, str(type(e)), str(e)))
 
-        passed = (retval == expected)
+        passed = retval == expected
 
         return passed
 
@@ -353,7 +347,7 @@ class FakeNetTester(object):
             # If the user specifies a minus sign before a regular expression,
             # match negatively (exclude any matching tests)
             for spec in matchspec:
-                if spec.startswith('-'):
+                if spec.startswith("-"):
                     negatives.append(spec[1:])
                 else:
                     positives.append(spec)
@@ -391,7 +385,7 @@ class FakeNetTester(object):
 
     def _mkzip(self, zip_path, files):
         zip_basename = os.path.splitext(os.path.split(zip_path)[-1])[0]
-        with zipfile.ZipFile(zip_path, mode='w') as z:
+        with zipfile.ZipFile(zip_path, mode="w") as z:
             for filepath in files:
                 filename = os.path.split(filepath)[-1]
                 arcname = os.path.join(zip_basename, filename)
@@ -401,7 +395,7 @@ class FakeNetTester(object):
     def _testGeneric(self, label, config, tests, matchspec=[]):
         self._filterMatchingTests(tests, matchspec)
         if not len(tests):
-            logger.info('No matching tests')
+            logger.info("No matching tests")
             return False
 
         # If doing a multi-host test, then toggle the network mode
@@ -416,37 +410,34 @@ class FakeNetTester(object):
                 return False
 
             sec = self.settings.sleep_after_start
-            logger.info('Sleeping %d seconds before commencing' % (sec))
+            logger.info("Sleeping %d seconds before commencing" % (sec))
             time.sleep(sec)
         else:
-            zip_path = os.path.join(self.settings.ancillary_files_dest,
-                                    'fakenet-test.zip')
-            afpaths = [os.path.join(self.settings.ancillary_files_dest, af)
-                       for af in self.settings.ancillary_files]
+            zip_path = os.path.join(self.settings.ancillary_files_dest, "fakenet-test.zip")
+            afpaths = [os.path.join(self.settings.ancillary_files_dest, af) for af in self.settings.ancillary_files]
             files = [self.settings.configpath] + afpaths
             self._mkzip(zip_path, files)
 
-            logger.info('Waiting for you to transition the remote FakeNet-NG')
-            logger.info('system to run the %s test suite' % (label))
-            logger.info(('***Copy and uncompress this archive on the test '
-                        'system: %s') % (zip_path))
-            logger.info('')
+            logger.info("Waiting for you to transition the remote FakeNet-NG")
+            logger.info("system to run the %s test suite" % (label))
+            logger.info(("***Copy and uncompress this archive on the test " "system: %s") % (zip_path))
+            logger.info("")
 
             while True:
-                logger.info('Type \'ok\' to continue, or \'exit\' to stop')
+                logger.info("Type 'ok' to continue, or 'exit' to stop")
                 try:
                     ok = input()
                 except EOFError:
-                    ok = 'exit'
+                    ok = "exit"
 
-                if ok.lower() in ['exit', 'quit', 'stop', 'n', 'no']:
+                if ok.lower() in ["exit", "quit", "stop", "n", "no"]:
                     sys.exit(0)
-                elif ok.lower() in ['ok', 'okay', 'go', 'y', 'yes']:
+                elif ok.lower() in ["ok", "okay", "go", "y", "yes"]:
                     break
 
-        logger.info('-' * 79)
-        logger.info('Testing')
-        logger.info('-' * 79)
+        logger.info("-" * 79)
+        logger.info("Testing")
+        logger.info("-" * 79)
 
         nPassedTests = 0
         nFailedTests = 0
@@ -454,12 +445,12 @@ class FakeNetTester(object):
 
         # Do each test
         for desc, (callback, args, expected) in tests.items():
-            logger.debug('Testing: %s' % (desc))
+            logger.debug("Testing: %s" % (desc))
             passed = self._tryTest(desc, callback, args, expected)
 
             # Retry in case of transient error e.g. timeout
             if not passed:
-                logger.debug('Retrying: %s' % (desc))
+                logger.debug("Retrying: %s" % (desc))
                 passed = self._tryTest(desc, callback, args, expected)
 
             if passed:
@@ -472,36 +463,35 @@ class FakeNetTester(object):
 
             time.sleep(0.5)
 
-        logger.info('-' * 79)
-        logger.info('Done.')
-        logger.info('Passed: %s/%s | Failed: %s/%s' % (nPassedTests, len(tests), nFailedTests, len(tests)))
+        logger.info("-" * 79)
+        logger.info("Done.")
+        logger.info("Passed: %s/%s | Failed: %s/%s" % (nPassedTests, len(tests), nFailedTests, len(tests)))
 
         if nFailedTests:
-            logger.info('\nFailed tests:')
+            logger.info("\nFailed tests:")
             for test in failedTests:
-                logger.info('[*] %s' % (test))
+                logger.info("[*] %s" % (test))
 
-        logger.info('-' * 79)
+        logger.info("-" * 79)
 
         if self.settings.singlehost:
             sec = self.settings.sleep_before_stop
-            logger.info('Sleeping %d seconds before transitioning' % (sec))
+            logger.info("Sleeping %d seconds before transitioning" % (sec))
             time.sleep(sec)
 
-            logger.info('Stopping FakeNet-NG and waiting for it to complete')
+            logger.info("Stopping FakeNet-NG and waiting for it to complete")
             responsive = self.stopFakenetAndWait(15, True)
 
             if responsive:
-                logger.info('FakeNet-NG is stopped')
+                logger.info("FakeNet-NG is stopped")
             else:
-                logger.info('FakeNet-NG was no longer running or was stopped forcibly')
+                logger.info("FakeNet-NG was no longer running or was stopped forcibly")
 
             time.sleep(1)
 
         self.delConfig()
 
-    def _test_sk(self, proto, host, port, teststring=None, expected=None,
-                 timeout=5):
+    def _test_sk(self, proto, host, port, teststring=None, expected=None, timeout=5):
         """Test socket-oriented"""
         retval = False
         s = socket.socket(socket.AF_INET, proto)
@@ -511,7 +501,7 @@ class FakeNetTester(object):
             s.connect((host, port))
 
             if teststring is None:
-                teststring = b'Testing FakeNet-NG'
+                teststring = b"Testing FakeNet-NG"
 
             if expected is None:
                 # RawListener is an echo server unless otherwise configured
@@ -522,22 +512,21 @@ class FakeNetTester(object):
             while remaining:
                 sent = s.send(teststring[-remaining:])
                 if sent == 0:
-                    raise IOError('Failed to send any bytes')
+                    raise IOError("Failed to send any bytes")
                 remaining -= sent
-                
-            recvd = ''
+
+            recvd = ""
 
             recvd = s.recv(4096)
 
-            retval = (recvd == expected)
+            retval = recvd == expected
             if not retval:
-                logger.error('Expected response: %s, Received response: %s' % (expected, recvd))
+                logger.error("Expected response: %s, Received response: %s" % (expected, recvd))
 
         except socket.error as e:
-            logger.error('Socket error: %s (%s %s:%d)' %
-                         (str(e), proto, host, port))
+            logger.error("Socket error: %s (%s %s:%d)" % (str(e), proto, host, port))
         except Exception as e:
-            logger.error('Non-socket Exception received: %s' % (str(e)))
+            logger.error("Non-socket Exception received: %s" % (str(e)))
 
         return retval
 
@@ -546,15 +535,15 @@ class FakeNetTester(object):
         return r.is_alive
 
     def _test_ns(self, hostname, expected):
-       return (expected == socket.gethostbyname(hostname))
+        return expected == socket.gethostbyname(hostname)
 
     def _test_smtp_ssl(self, sender, recipient, msg, hostname, port=None, timeout=5):
-        smtpserver = smtplib.SMTP_SSL(hostname, port, 'fake.net', None, None, timeout)
+        smtpserver = smtplib.SMTP_SSL(hostname, port, "fake.net", None, None, timeout)
         server.sendmail(sender, recipient, msg)
         smtpserver.quit()
 
     def _test_smtp(self, sender, recipient, msg, hostname, port=None, timeout=5):
-        smtpserver = smtplib.SMTP(hostname, port, 'fake.net', timeout)
+        smtpserver = smtplib.SMTP(hostname, port, "fake.net", timeout)
         smtpserver.sendmail(sender, recipient, msg)
         smtpserver.quit()
 
@@ -562,26 +551,26 @@ class FakeNetTester(object):
 
     def _test_pop(self, hostname, port=None, timeout=5):
         pop3server = poplib.POP3(hostname, port, timeout)
-        pop3server.user('popuser')
-        pop3server.pass_('password')
+        pop3server.user("popuser")
+        pop3server.pass_("password")
         msg = pop3server.retr(1)
 
         response = msg[0]
         lines = msg[1]
         octets = msg[2]
 
-        if not response.startswith(b'+OK'):
+        if not response.startswith(b"+OK"):
             msg = 'POP3 response does not start with "+OK"'
             logger.error(msg)
             return False
 
-        if not b'Alice' in b''.join(lines):
-            msg = 'POP3 message did not contain expected string'
+        if not b"Alice" in b"".join(lines):
+            msg = "POP3 message did not contain expected string"
             raise FakeNetTestException(msg)
             return False
 
         return True
-        
+
     def _util_irc(self, nm, hostname, port, nick, callback):
         r = irc.client.Reactor()
         srv = r.server()
@@ -594,8 +583,7 @@ class FakeNetTester(object):
         irc_tester = IrcTester(hostname, port)
         return irc_tester.test_irc()
 
-    def _test_http(self, hostname, port=None, scheme=None, uri=None,
-                   teststring=None, verify=False):
+    def _test_http(self, hostname, port=None, scheme=None, uri=None, teststring=None, verify=False):
         """Test HTTP Listener"""
 
         # https://stackoverflow.com/a/50215614
@@ -604,22 +592,22 @@ class FakeNetTester(object):
             def init_poolmanager(self, *args, **kwargs):
                 ctx = ssl.create_default_context()
                 ctx.load_default_certs()
-                kwargs['ssl_context'] = ctx
+                kwargs["ssl_context"] = ctx
                 return super(SSLContextAdapter, self).init_poolmanager(*args, **kwargs)
 
         retval = False
         sess = requests.Session()
 
-        scheme = scheme if scheme else 'http'
-        uri = uri.lstrip('/') if uri else 'asdf.html'
-        teststring = teststring if teststring else 'H T T P   L I S T E N E R'
+        scheme = scheme if scheme else "http"
+        uri = uri.lstrip("/") if uri else "asdf.html"
+        teststring = teststring if teststring else "H T T P   L I S T E N E R"
 
         if port:
-            url = '%s://%s:%d/%s' % (scheme, hostname, port, uri)
+            url = "%s://%s:%d/%s" % (scheme, hostname, port, uri)
         else:
-            url = '%s://%s/%s' % (scheme, hostname, uri)
+            url = "%s://%s/%s" % (scheme, hostname, uri)
 
-        if (scheme == "https") and verify and sys.platform.startswith('win32'):
+        if (scheme == "https") and verify and sys.platform.startswith("win32"):
             adapter = SSLContextAdapter()
             sess.mount(url, adapter)
 
@@ -627,10 +615,10 @@ class FakeNetTester(object):
             r = sess.get(url, timeout=3, verify=verify)
 
             if r.status_code != 200:
-                raise FakeNetTestException('Status code %d' % (r.status_code))
+                raise FakeNetTestException("Status code %d" % (r.status_code))
 
             if teststring not in r.text:
-                raise FakeNetTestException('Test string not in response')
+                raise FakeNetTestException("Test string not in response")
 
             retval = True
 
@@ -654,7 +642,7 @@ class FakeNetTester(object):
         listens silently for the server 220 welcome message which doesn't give
         the Proxy listener anything to work with to decide where to forward it.
         """
-        fullbuf = ''
+        fullbuf = ""
 
         m = hashlib.md5()
 
@@ -665,13 +653,13 @@ class FakeNetTester(object):
         f.connect(hostname, port)
         f.login()
         f.set_pasv(False)
-        f.retrbinary('RETR FakeNet.gif', update_hash)
+        f.retrbinary("RETR FakeNet.gif", update_hash)
         f.quit()
 
         digest = m.digest()
-        expected = binascii.unhexlify('a6b78c4791dc8110dec6c55f8a756395')
+        expected = binascii.unhexlify("a6b78c4791dc8110dec6c55f8a756395")
 
-        return (digest == expected)
+        return digest == expected
 
     def testNoRedirect(self, matchspec=[]):
         config = self.makeConfig(singlehostmode=True, proxied=False, redirectall=False)
@@ -684,22 +672,22 @@ class FakeNetTester(object):
         tcp = socket.SOCK_STREAM
         udp = socket.SOCK_DGRAM
 
-        t = OrderedDict() # The tests
+        t = OrderedDict()  # The tests
 
-        t['RedirectAllTraffic disabled external IP @ bound'] = (self._test_sk, (tcp, ext_ip, 1337), True)
-        t['RedirectAllTraffic disabled external IP @ unbound'] = (self._test_sk, (tcp, ext_ip, 9999), False)
+        t["RedirectAllTraffic disabled external IP @ bound"] = (self._test_sk, (tcp, ext_ip, 1337), True)
+        t["RedirectAllTraffic disabled external IP @ unbound"] = (self._test_sk, (tcp, ext_ip, 9999), False)
 
-        t['RedirectAllTraffic disabled arbitrary host @ bound'] = (self._test_sk, (tcp, arbitrary, 1337), False)
-        t['RedirectAllTraffic disabled arbitrary host @ unbound'] = (self._test_sk, (tcp, arbitrary, 9999), False)
+        t["RedirectAllTraffic disabled arbitrary host @ bound"] = (self._test_sk, (tcp, arbitrary, 1337), False)
+        t["RedirectAllTraffic disabled arbitrary host @ unbound"] = (self._test_sk, (tcp, arbitrary, 9999), False)
 
-        t['RedirectAllTraffic disabled named host @ bound'] = (self._test_sk, (tcp, domain_dne, 1337), False)
-        t['RedirectAllTraffic disabled named host @ unbound'] = (self._test_sk, (tcp, domain_dne, 9999), False)
+        t["RedirectAllTraffic disabled named host @ bound"] = (self._test_sk, (tcp, domain_dne, 1337), False)
+        t["RedirectAllTraffic disabled named host @ unbound"] = (self._test_sk, (tcp, domain_dne, 9999), False)
 
         if self.settings.singlehost:
-            t['RedirectAllTraffic disabled localhost @ bound'] = (self._test_sk, (tcp, localhost, 1337), True)
-            t['RedirectAllTraffic disabled localhost @ unbound'] = (self._test_sk, (tcp, localhost, 9999), False)
+            t["RedirectAllTraffic disabled localhost @ bound"] = (self._test_sk, (tcp, localhost, 1337), True)
+            t["RedirectAllTraffic disabled localhost @ unbound"] = (self._test_sk, (tcp, localhost, 9999), False)
 
-        return self._testGeneric('No Redirect', config, t, matchspec)
+        return self._testGeneric("No Redirect", config, t, matchspec)
 
     def testBlacklistProcess(self, matchspec=[]):
         config = self.makeConfig()
@@ -710,12 +698,12 @@ class FakeNetTester(object):
         tcp = socket.SOCK_STREAM
         udp = socket.SOCK_DGRAM
 
-        t = OrderedDict() # The tests
+        t = OrderedDict()  # The tests
 
         if self.settings.singlehost:
-            t['Global blacklisted process test'] = (self._test_sk, (tcp, arbitrary, 9999), False)
+            t["Global blacklisted process test"] = (self._test_sk, (tcp, arbitrary, 9999), False)
 
-        return self._testGeneric('Global process blacklist', config, t, matchspec)
+        return self._testGeneric("Global process blacklist", config, t, matchspec)
 
     def testWhitelistProcess(self, matchspec=[]):
         config = self.makeConfig()
@@ -726,12 +714,12 @@ class FakeNetTester(object):
         tcp = socket.SOCK_STREAM
         udp = socket.SOCK_DGRAM
 
-        t = OrderedDict() # The tests
+        t = OrderedDict()  # The tests
 
         if self.settings.singlehost:
-            t['Global whitelisted process test'] = (self._test_sk, (tcp, arbitrary, 9999), True)
+            t["Global whitelisted process test"] = (self._test_sk, (tcp, arbitrary, 9999), True)
 
-        return self._testGeneric('Global process whitelist', config, t, matchspec)
+        return self._testGeneric("Global process whitelist", config, t, matchspec)
 
     def testGeneral(self, matchspec=[]):
         config = self.makeConfig()
@@ -755,96 +743,137 @@ class FakeNetTester(object):
         tcp = socket.SOCK_STREAM
         udp = socket.SOCK_DGRAM
 
-        t = OrderedDict() # The tests
+        t = OrderedDict()  # The tests
 
-        t['TCP external IP @ bound'] = (self._test_sk, (tcp, ext_ip, 1337), True)
-        t['TCP external IP @ unbound'] = (self._test_sk, (tcp, ext_ip, 9999), True)
-        t['TCP arbitrary @ bound'] = (self._test_sk, (tcp, arbitrary, 1337), True)
-        t['TCP arbitrary @ unbound'] = (self._test_sk, (tcp, arbitrary, 9999), True)
-        t['TCP domainname @ bound'] = (self._test_sk, (tcp, domain_dne, 1337), True)
-        t['TCP domainname @ unbound'] = (self._test_sk, (tcp, domain_dne, 9999), True)
+        t["TCP external IP @ bound"] = (self._test_sk, (tcp, ext_ip, 1337), True)
+        t["TCP external IP @ unbound"] = (self._test_sk, (tcp, ext_ip, 9999), True)
+        t["TCP arbitrary @ bound"] = (self._test_sk, (tcp, arbitrary, 1337), True)
+        t["TCP arbitrary @ unbound"] = (self._test_sk, (tcp, arbitrary, 9999), True)
+        t["TCP domainname @ bound"] = (self._test_sk, (tcp, domain_dne, 1337), True)
+        t["TCP domainname @ unbound"] = (self._test_sk, (tcp, domain_dne, 9999), True)
         if self.settings.singlehost:
-            t['TCP localhost @ bound'] = (self._test_sk, (tcp, localhost, 1337), True)
-            t['TCP localhost @ unbound'] = (self._test_sk, (tcp, localhost, 9999), False)
+            t["TCP localhost @ bound"] = (self._test_sk, (tcp, localhost, 1337), True)
+            t["TCP localhost @ unbound"] = (self._test_sk, (tcp, localhost, 9999), False)
 
-        t['TCP custom test static Base64'] = (self._test_sk, (tcp, ext_ip, 1000, b'whatever', b'\x0fL\x0aR\x0e'), True)
-        t['TCP custom test static string'] = (self._test_sk, (tcp, ext_ip, 1001, b'whatever', b'static string TCP response'), True)
-        t['TCP custom test static file'] = (self._test_sk, (tcp, ext_ip, 1002, b'whatever', b'sample TCP raw file response'), True)
-        whatever = b'whatever'  # Ensures matching test/expected for TCP dynamic
-        t['TCP custom test dynamic'] = (self._test_sk, (tcp, ext_ip, 1003, whatever, b''.join([chr(c+1).encode("utf-8") for c in whatever])), True)
+        t["TCP custom test static Base64"] = (self._test_sk, (tcp, ext_ip, 1000, b"whatever", b"\x0fL\x0aR\x0e"), True)
+        t["TCP custom test static string"] = (
+            self._test_sk,
+            (tcp, ext_ip, 1001, b"whatever", b"static string TCP response"),
+            True,
+        )
+        t["TCP custom test static file"] = (
+            self._test_sk,
+            (tcp, ext_ip, 1002, b"whatever", b"sample TCP raw file response"),
+            True,
+        )
+        whatever = b"whatever"  # Ensures matching test/expected for TCP dynamic
+        t["TCP custom test dynamic"] = (
+            self._test_sk,
+            (tcp, ext_ip, 1003, whatever, b"".join([chr(c + 1).encode("utf-8") for c in whatever])),
+            True,
+        )
 
-        t['UDP external IP @ bound'] = (self._test_sk, (udp, ext_ip, 1337), True)
-        t['UDP external IP @ unbound'] = (self._test_sk, (udp, ext_ip, 9999), True)
-        t['UDP arbitrary @ bound'] = (self._test_sk, (udp, arbitrary, 1337), True)
-        t['UDP arbitrary @ unbound'] = (self._test_sk, (udp, arbitrary, 9999), True)
-        t['UDP domainname @ bound'] = (self._test_sk, (udp, domain_dne, 1337), True)
-        t['UDP domainname @ unbound'] = (self._test_sk, (udp, domain_dne, 9999), True)
+        t["UDP external IP @ bound"] = (self._test_sk, (udp, ext_ip, 1337), True)
+        t["UDP external IP @ unbound"] = (self._test_sk, (udp, ext_ip, 9999), True)
+        t["UDP arbitrary @ bound"] = (self._test_sk, (udp, arbitrary, 1337), True)
+        t["UDP arbitrary @ unbound"] = (self._test_sk, (udp, arbitrary, 9999), True)
+        t["UDP domainname @ bound"] = (self._test_sk, (udp, domain_dne, 1337), True)
+        t["UDP domainname @ unbound"] = (self._test_sk, (udp, domain_dne, 9999), True)
         if self.settings.singlehost:
-            t['UDP localhost @ bound'] = (self._test_sk, (udp, localhost, 1337), True)
-            t['UDP localhost @ unbound'] = (self._test_sk, (udp, localhost, 9999), False)
+            t["UDP localhost @ bound"] = (self._test_sk, (udp, localhost, 1337), True)
+            t["UDP localhost @ unbound"] = (self._test_sk, (udp, localhost, 9999), False)
 
-        t['UDP custom test static Base64'] = (self._test_sk, (udp, ext_ip, 1000, b'whatever', b'\x0fL\x0aR\x0e'), True)
-        whatever = b'whatever2'  # Ensures matching test/expected for UDP dynamic
-        t['UDP custom test dynamic'] = (self._test_sk, (udp, ext_ip, 1003, whatever, b''.join([chr(c+1).encode("utf-8") for c in whatever])), True)
+        t["UDP custom test static Base64"] = (self._test_sk, (udp, ext_ip, 1000, b"whatever", b"\x0fL\x0aR\x0e"), True)
+        whatever = b"whatever2"  # Ensures matching test/expected for UDP dynamic
+        t["UDP custom test dynamic"] = (
+            self._test_sk,
+            (udp, ext_ip, 1003, whatever, b"".join([chr(c + 1).encode("utf-8") for c in whatever])),
+            True,
+        )
 
-        t['ICMP external IP'] = (self._test_icmp, (ext_ip,), True)
-        t['ICMP arbitrary host'] = (self._test_icmp, (arbitrary,), True)
-        t['ICMP domainname'] = (self._test_icmp, (domain_dne,), True)
+        t["ICMP external IP"] = (self._test_icmp, (ext_ip,), True)
+        t["ICMP arbitrary host"] = (self._test_icmp, (arbitrary,), True)
+        t["ICMP domainname"] = (self._test_icmp, (domain_dne,), True)
 
-        t['DNS listener test'] = (self._test_ns, (domain_dne, dns_expected), True)
-        t['HTTP listener test'] = (self._test_http, (arbitrary,), True)
-        t['HTTPS listener IP test, no verify'] = (self._test_http, (arbitrary, None, 'https', None, None, False), True)
-        t['HTTPS listener IP test'] = (self._test_http, (arbitrary, None, 'https', None, None, True), False)
+        t["DNS listener test"] = (self._test_ns, (domain_dne, dns_expected), True)
+        t["HTTP listener test"] = (self._test_http, (arbitrary,), True)
+        t["HTTPS listener IP test, no verify"] = (self._test_http, (arbitrary, None, "https", None, None, False), True)
+        t["HTTPS listener IP test"] = (self._test_http, (arbitrary, None, "https", None, None, True), False)
 
         # Server Name Indication implementation works best on Windows platform
         # See https://github.com/mandiant/flare-fakenet-ng/pull/98#issuecomment-552222568
         if self.settings.windows:
-            t['HTTPS listener hostname test'] = (self._test_http, ('evil.com', None, 'https', 'test.html', None, True), True)
-        t['HTTP custom test by URI'] = (self._test_http, (arbitrary, None, None, '/test.txt', 'Wraps this'), True)
-        t['HTTP custom test by hostname'] = (self._test_http, ('some.random.c2.com', None, None, None, 'success'), True)
-        t['HTTP custom test by both URI and hostname'] = (self._test_http, ('both_host.com', None, None, '/and_uri.txt', 'Ahoy'), True)
-        t['HTTP custom test by both URI and hostname wrong URI'] = (self._test_http, ('both_host.com', None, None, '/not_uri.txt', 'Ahoy'), False)
-        t['HTTP custom test by both URI and hostname wrong hostname'] = (self._test_http, ('non_host.com', None, None, '/and_uri.txt', 'Ahoy'), False)
-        t['HTTP custom test by ListenerType'] = (self._test_http, ('other.c2.com', 81, None, '/whatever.html', 'success'), True)
-        t['HTTP custom test by ListenerType host port negative match'] = (self._test_http, ('other.c2.com', 80, None, '/whatever.html', 'success'), False)
-        t['FTP listener test'] = (self._test_ftp, (arbitrary,), True)
-        t['POP3 listener test'] = (self._test_pop, (arbitrary, 110), True)
-        t['SMTP listener test'] = (self._test_smtp, (sender, recipient, smtpmsg, arbitrary), True)
+            t["HTTPS listener hostname test"] = (
+                self._test_http,
+                ("evil.com", None, "https", "test.html", None, True),
+                True,
+            )
+        t["HTTP custom test by URI"] = (self._test_http, (arbitrary, None, None, "/test.txt", "Wraps this"), True)
+        t["HTTP custom test by hostname"] = (self._test_http, ("some.random.c2.com", None, None, None, "success"), True)
+        t["HTTP custom test by both URI and hostname"] = (
+            self._test_http,
+            ("both_host.com", None, None, "/and_uri.txt", "Ahoy"),
+            True,
+        )
+        t["HTTP custom test by both URI and hostname wrong URI"] = (
+            self._test_http,
+            ("both_host.com", None, None, "/not_uri.txt", "Ahoy"),
+            False,
+        )
+        t["HTTP custom test by both URI and hostname wrong hostname"] = (
+            self._test_http,
+            ("non_host.com", None, None, "/and_uri.txt", "Ahoy"),
+            False,
+        )
+        t["HTTP custom test by ListenerType"] = (
+            self._test_http,
+            ("other.c2.com", 81, None, "/whatever.html", "success"),
+            True,
+        )
+        t["HTTP custom test by ListenerType host port negative match"] = (
+            self._test_http,
+            ("other.c2.com", 80, None, "/whatever.html", "success"),
+            False,
+        )
+        t["FTP listener test"] = (self._test_ftp, (arbitrary,), True)
+        t["POP3 listener test"] = (self._test_pop, (arbitrary, 110), True)
+        t["SMTP listener test"] = (self._test_smtp, (sender, recipient, smtpmsg, arbitrary), True)
 
         # Does not work, SSL error
-        t['SMTP SSL listener test'] = (self._test_smtp_ssl, (sender, recipient, smtpmsg, arbitrary), True)
+        t["SMTP SSL listener test"] = (self._test_smtp_ssl, (sender, recipient, smtpmsg, arbitrary), True)
 
         # Works on Linux, not on Windows
-        t['IRC listener test'] = (self._test_irc, (arbitrary,), True)
+        t["IRC listener test"] = (self._test_irc, (arbitrary,), True)
 
-        t['Proxy listener HTTP test'] = (self._test_http, (arbitrary, no_service), True)
-        t['Proxy listener HTTP hidden test'] = (self._test_http, (arbitrary, hidden_tcp), True)
+        t["Proxy listener HTTP test"] = (self._test_http, (arbitrary, no_service), True)
+        t["Proxy listener HTTP hidden test"] = (self._test_http, (arbitrary, hidden_tcp), True)
 
-        t['TCP blacklisted host @ unbound'] = (self._test_sk, (tcp, blacklistedhost, 9999), False)
-        t['TCP arbitrary @ blacklisted unbound'] = (self._test_sk, (tcp, arbitrary, blacklistedtcp), False)
-        t['UDP arbitrary @ blacklisted unbound'] = (self._test_sk, (udp, arbitrary, blacklistedudp), False)
+        t["TCP blacklisted host @ unbound"] = (self._test_sk, (tcp, blacklistedhost, 9999), False)
+        t["TCP arbitrary @ blacklisted unbound"] = (self._test_sk, (tcp, arbitrary, blacklistedtcp), False)
+        t["UDP arbitrary @ blacklisted unbound"] = (self._test_sk, (udp, arbitrary, blacklistedudp), False)
         if self.settings.windows:
-            t['ICMP arbitrary @ blacklisted'] = (self._test_icmp, (arbitrary, blacklistedicmp), False)
+            t["ICMP arbitrary @ blacklisted"] = (self._test_icmp, (arbitrary, blacklistedicmp), False)
 
         if self.settings.singlehost:
-            t['Listener process blacklist'] = (self._test_http, (arbitrary, self.settings.listener_proc_black), False)
-            t['Listener process whitelist'] = (self._test_http, (arbitrary, self.settings.listener_proc_white), True)
-            t['Listener host blacklist'] = (self._test_http, (arbitrary, self.settings.listener_host_black), True)
-            t['Listener host whitelist'] = (self._test_http, (arbitrary, self.settings.listener_host_black), True)
+            t["Listener process blacklist"] = (self._test_http, (arbitrary, self.settings.listener_proc_black), False)
+            t["Listener process whitelist"] = (self._test_http, (arbitrary, self.settings.listener_proc_white), True)
+            t["Listener host blacklist"] = (self._test_http, (arbitrary, self.settings.listener_host_black), True)
+            t["Listener host whitelist"] = (self._test_http, (arbitrary, self.settings.listener_host_black), True)
 
-        return self._testGeneric('General', config, t, matchspec)
+        return self._testGeneric("General", config, t, matchspec)
 
     def makeConfig(self, singlehostmode=True, proxied=True, redirectall=True):
         template = self.settings.configtemplate
         return FakeNetConfig(template, singlehostmode, proxied, redirectall)
 
     def writeConfig(self, config):
-        logger.info('Writing config to %s' % (self.settings.configpath))
+        logger.info("Writing config to %s" % (self.settings.configpath))
         config.write(self.settings.configpath)
         for filename in self.settings.ancillary_files:
             path = os.path.join(self.settings.startingpath, filename)
             dest = os.path.join(self.settings.ancillary_files_dest, filename)
             shutil.copyfile(path, dest)
+
 
 class FakeNetConfig:
     """Convenience class to read/modify/rewrite a configuration template."""
@@ -858,31 +887,39 @@ class FakeNetConfig:
         else:
             self.multiHostMode()
 
-        if not proxied: self.noProxy()
+        if not proxied:
+            self.noProxy()
 
         self.setRedirectAll(redirectall)
 
-    def blacklistProcess(self, process): self.rawconfig.set('Diverter', 'ProcessBlacklist', process)
-    def whitelistProcess(self, process): self.rawconfig.set('Diverter', 'ProcessWhitelist', process)
+    def blacklistProcess(self, process):
+        self.rawconfig.set("Diverter", "ProcessBlacklist", process)
+
+    def whitelistProcess(self, process):
+        self.rawconfig.set("Diverter", "ProcessWhitelist", process)
 
     def setRedirectAll(self, enabled):
         if enabled:
-            self.rawconfig.set('Diverter', 'RedirectAllTraffic', 'Yes')
+            self.rawconfig.set("Diverter", "RedirectAllTraffic", "Yes")
         else:
-            self.rawconfig.set('Diverter', 'RedirectAllTraffic', 'No')
+            self.rawconfig.set("Diverter", "RedirectAllTraffic", "No")
 
-    def singleHostMode(self): self.rawconfig.set('Diverter', 'NetworkMode', 'SingleHost')
-    def multiHostMode(self): self.rawconfig.set('Diverter', 'NetworkMode', 'MultiHost')
+    def singleHostMode(self):
+        self.rawconfig.set("Diverter", "NetworkMode", "SingleHost")
+
+    def multiHostMode(self):
+        self.rawconfig.set("Diverter", "NetworkMode", "MultiHost")
 
     def noProxy(self):
-        self.rawconfig.remove_section('ProxyTCPListener')
-        self.rawconfig.remove_section('ProxyUDPListener')
-        self.rawconfig.set('Diverter', 'DefaultTCPListener', 'RawTCPListener')
-        self.rawconfig.set('Diverter', 'DefaultUDPListener', 'RawUDPListener')
+        self.rawconfig.remove_section("ProxyTCPListener")
+        self.rawconfig.remove_section("ProxyUDPListener")
+        self.rawconfig.set("Diverter", "DefaultTCPListener", "RawTCPListener")
+        self.rawconfig.set("Diverter", "DefaultUDPListener", "RawUDPListener")
 
     def write(self, path):
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             return self.rawconfig.write(f)
+
 
 class FakeNetTestSettings:
     """Test constants/literals, some of which may vary per OS, etc."""
@@ -890,51 +927,51 @@ class FakeNetTestSettings:
     def __init__(self, startingpath, singlehost=True):
         # Where am I? Who are you?
         self.platform_name = platform.system()
-        self.windows = (self.platform_name == 'Windows')
-        self.linux = (self.platform_name.lower().startswith('linux'))
+        self.windows = self.platform_name == "Windows"
+        self.linux = self.platform_name.lower().startswith("linux")
 
         # Test parameters
         self.singlehost = singlehost
         self.startingpath = startingpath
-        self.configtemplate = os.path.join(startingpath, 'template.ini')
+        self.configtemplate = os.path.join(startingpath, "template.ini")
 
-        self.ancillary_files_dest = self.genPath('%TEMP%', '/tmp/')
+        self.ancillary_files_dest = self.genPath("%TEMP%", "/tmp/")
         self.ancillary_files = [
-            'custom_responses.ini',
-            'CustomProviderExample.py',
-            'sample_raw_response.txt',
-            'sample_raw_tcp_response.txt',
+            "custom_responses.ini",
+            "CustomProviderExample.py",
+            "sample_raw_response.txt",
+            "sample_raw_tcp_response.txt",
         ]
 
         # Paths
-        self.configpath = self.genPath('%TEMP%\\fakenet.ini', '/tmp/fakenet.ini')
-        self.stopflag = self.genPath('%TEMP%\\stop_fakenet', '/tmp/stop_fakenet')
-        self.logpath = self.genPath('%TEMP%\\fakenet.log', '/tmp/fakenet.log')
-        self.fakenet = self.genPath('fakenet', 'python3 -m fakenet.fakenet')
-        self.fndir = self.genPath('.', os.path.dirname(os.getcwd()))
+        self.configpath = self.genPath("%TEMP%\\fakenet.ini", "/tmp/fakenet.ini")
+        self.stopflag = self.genPath("%TEMP%\\stop_fakenet", "/tmp/stop_fakenet")
+        self.logpath = self.genPath("%TEMP%\\fakenet.log", "/tmp/fakenet.log")
+        self.fakenet = self.genPath("fakenet", "python3 -m fakenet.fakenet")
+        self.fndir = self.genPath(".", os.path.dirname(os.getcwd()))
 
         # For process blacklisting
         self.pythonname = os.path.basename(sys.executable)
 
         # Various
         self.ext_ip = get_external_ip()
-        self.arbitrary = '8.8.8.8'
-        self.blacklistedhost = '6.6.6.6'
+        self.arbitrary = "8.8.8.8"
+        self.blacklistedhost = "6.6.6.6"
         self.blacklistedtcp = 139
         self.blacklistedudp = 67
         self.blacklistedicmp = 1234
-        self.hidden_tcp =  12345
+        self.hidden_tcp = 12345
         self.no_service = 10
-        self.listener_proc_black = 8080 # HTTP listener with process blacklist
-        self.listener_proc_white = 8081 # HTTP listener with process whitelists
-        self.listener_host_black = 8082 # HTTP listener with host blacklist
-        self.listener_host_white = 8083 # HTTP listener with host whitelists
-        self.localhost = '127.0.0.1'
-        self.dns_expected = '192.0.2.123'
-        self.domain_dne = 'does-not-exist-amirite.mandiant.com'
-        self.sender = 'from-fakenet@example.org'
-        self.recipient = 'to-fakenet@example.org'
-        self.smtpmsg = 'FakeNet-NG SMTP test email'
+        self.listener_proc_black = 8080  # HTTP listener with process blacklist
+        self.listener_proc_white = 8081  # HTTP listener with process whitelists
+        self.listener_host_black = 8082  # HTTP listener with host blacklist
+        self.listener_host_white = 8083  # HTTP listener with host whitelists
+        self.localhost = "127.0.0.1"
+        self.dns_expected = "192.0.2.123"
+        self.domain_dne = "does-not-exist-amirite.mandiant.com"
+        self.sender = "from-fakenet@example.org"
+        self.recipient = "to-fakenet@example.org"
+        self.smtpmsg = "FakeNet-NG SMTP test email"
 
         # Behaviors
         self.sleep_after_start = 4
@@ -947,60 +984,61 @@ class FakeNetTestSettings:
             return os.path.expandvars(unixypath)
 
     def genFakenetCmd(self):
-        return ('%s -f %s -n -l %s -c %s' %
-                (self.fakenet, self.stopflag, self.logpath, self.configpath))
+        return "%s -f %s -n -l %s -c %s" % (self.fakenet, self.stopflag, self.logpath, self.configpath)
+
 
 def is_ip(s):
-    pat = r'^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'
+    pat = r"^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"
     return bool(re.match(pat, s))
+
 
 def main():
     if not is_admin():
-        logger.error('Not an admin, exiting...')
+        logger.error("Not an admin, exiting...")
         sys.exit(1)
 
     if len(sys.argv) < 2:
-        logger.error('Usage: test.py <where> [matchspec1 [matchspec2 [...] ] ]')
-        logger.error('')
-        logger.error('Valid where:')
-        logger.error('  here')
-        logger.error('  Any dot-decimal IP address')
-        logger.error('')
-        logger.error('Each match specification is a regular expression that')
-        logger.error('will be compared against test names, and any matches')
-        logger.error('will be included. Because regular expression negative')
-        logger.error('matching is complicated to use, you can just prefix')
-        logger.error('a match specification with a minus sign to indicate')
-        logger.error('that you would like to include only tests that do NOT')
-        logger.error('match the expression.')
+        logger.error("Usage: test.py <where> [matchspec1 [matchspec2 [...] ] ]")
+        logger.error("")
+        logger.error("Valid where:")
+        logger.error("  here")
+        logger.error("  Any dot-decimal IP address")
+        logger.error("")
+        logger.error("Each match specification is a regular expression that")
+        logger.error("will be compared against test names, and any matches")
+        logger.error("will be included. Because regular expression negative")
+        logger.error("matching is complicated to use, you can just prefix")
+        logger.error("a match specification with a minus sign to indicate")
+        logger.error("that you would like to include only tests that do NOT")
+        logger.error("match the expression.")
         sys.exit(1)
 
     # Validate where
     where = sys.argv[1]
 
-    singlehost = (where.lower() == 'here')
+    singlehost = where.lower() == "here"
 
     if not singlehost and not is_ip(where):
-        logger.error('Invalid where: %s' % (where))
+        logger.error("Invalid where: %s" % (where))
         sys.exit(1)
 
     # Will execute only tests matching *match_spec if specified
     match_spec = sys.argv[2:]
 
     if len(match_spec):
-        logger.info('Only running tests that match the following ' +
-                    'specifications:')
+        logger.info("Only running tests that match the following " + "specifications:")
         for spec in match_spec:
-            logger.info('  %s' % (spec))
+            logger.info("  %s" % (spec))
 
     # Doit
     startingpath = os.getcwd()
     settings = FakeNetTestSettings(startingpath, singlehost)
-    if not singlehost: # <where> was an IP, so record it
+    if not singlehost:  # <where> was an IP, so record it
         settings.ext_ip = where
     tester = FakeNetTester(settings)
-    logger.info('Running with privileges on %s' % (settings.platform_name))
+    logger.info("Running with privileges on %s" % (settings.platform_name))
     tester.doTests(match_spec)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR reformats the entire codebase using the 'black' code formatter to ensure a consistent and readable style. The formatting was applied with the command: `black --line-length=120 .`

To maintain this style, a new GitHub Actions workflow (`.github/workflows/ci.yml`) has been added. This CI job automatically runs `black --check` on all pushes and pull requests.

Automating style enforcement is beneficial for project health because it:
- **Improves Code Review Efficiency:** Reviewers can focus on the core logic and functionality of a change, rather than spending time on manual formatting nitpicks.
- **Ensures Consistency:** A uniform style makes the codebase easier to read, understand, and maintain for everyone.
- **Lowers Contribution Barrier:** Contributors don't have to guess the project's style rules; the linter provides immediate, automated feedback.

You can see the workflow running in the following example PR (it fails on purpose): https://github.com/Ana06/flare-fakenet-ng/pull/5. It should also run in this PR (and not fail as the offenses are fixed):